### PR TITLE
Add teams/governance to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## Governance
+
+Ahead of v1 release, the governance for the TIDES suite of data specifications is being kept lightweight in order to increase velocity towards a usable product.  The governance for the specification will be revisited as the v1 release approaches.
+
+## Teams
+
+The TIDES specifications shall be shepherded by the following groups:
+
+- Leadership  
+- Product Management  
+- Contributors  
+- Stakeholders  
+
+### Leadership
+
+Responsible for overall direction and decisionmaking on the project including: working group composition and scopes, approval of the final specification designs for v1.0 (based on the feedback of stakeholders), and approval of the governance plan created by the governance working group.
+
+Members: John Levin, Metropolitan Transit (MN)
+
+[Github Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Admin
+
+### Product Management Team
+
+Responsible for creating and maintaining backbone standards infrastructure, processes, and delivery of a final design (v1.0) of the standards suite with the help of and in alignment with the Contributors.
+
+Members:  
+
+- Hunter Owens, Caltrans  
+- Jameelah Young, Jarv.us (on behalf of Caltrans)  
+- Elizabeth Sall, UrbanLabs LLC (on behalf of Caltrans)  
+- Benjamin Bressette, Caltrans  
+- Blake Fleisher, Jarv.us (on behalf of Caltrans)  
+- Joey Reid, Metropolitan Transit (MN)  
+
+[Github Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Admin
+
+### Contributors
+
+A group actively working to implement the conceptual design  specifications which can raise and work through implementation issues with the Product Management Team and get to an implementable specification and final initial design (v1.0).
+
+Members:  TBD.  Survey of interest to be released by Leadership team.
+
+[Github Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Write
+
+### Stakeholders
+
+Informed about progress; asked if interested in participating more fully; consulted for comments  in the final design process.
+
+[Github Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Read/Create Issues (same as general public)


### PR DESCRIPTION
This pull request implements the initial governance of the TIDES data schemas as agreed to by the BDFNow John Levin.