### PR TITLE
Fixes for workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
+        python-version: '3.x'
         cache: 'pip'
     - name: Install dependencies
       run: |

--- a/.github/workflows/validate_package_noop.yml
+++ b/.github/workflows/validate_package_noop.yml
@@ -1,0 +1,14 @@
+name: Validate Frictionless Data Package Schema for Spec
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '!spec/tides.spec.json$'
+
+jobs:
+  validate_data_package:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "no validation required"'

--- a/.github/workflows/validate_package_noop.yml
+++ b/.github/workflows/validate_package_noop.yml
@@ -11,4 +11,4 @@ jobs:
   validate_data_package:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "no validation required"'
+      - run: 'echo "no changes to spec/tides.schema.json: no validation required"'

--- a/.github/workflows/validate_package_schema.yml
+++ b/.github/workflows/validate_package_schema.yml
@@ -1,12 +1,14 @@
-name: Validate Frictionless JSON Schemas for Spec
+name: Validate Frictionless Data Package Schema for Spec
 
 on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'spec/tides.spec.json$'
 
 jobs:
-  validate_schemas:
+  validate_data_package:
     name: Validate Frictionless Schemas
     runs-on: ubuntu-latest
     steps:
@@ -19,9 +21,3 @@ jobs:
           json_path_pattern: ^spec/tides\.spec\.json$
           send_comment: true
           clear_comments: true
-      - name: Validate other schema
-        uses: snapcart/json-schema-validator@v1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          json_schema: "https://specs.frictionlessdata.io/schemas/table-schema.json"
-          json_path_pattern: ^spec/.*\.schema\.json$

--- a/.github/workflows/validate_schemas.yml
+++ b/.github/workflows/validate_schemas.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           json_schema: "https://specs.frictionlessdata.io/schemas/data-package.json"
-          json_path_pattern: tides.spec.json
+          json_path_pattern: ^spec/tides\.spec\.json$
           send_comment: true
           clear_comments: true
       - name: Validate other schema

--- a/.github/workflows/validate_schemas.yml
+++ b/.github/workflows/validate_schemas.yml
@@ -1,6 +1,9 @@
 name: Validate Frictionless JSON Schemas for Spec
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   validate_schemas:

--- a/.github/workflows/validate_schemas.yml
+++ b/.github/workflows/validate_schemas.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           json_schema: "https://specs.frictionlessdata.io/schemas/data-package.json"
-          json_path_pattern: ^spec/tides\.spec\.json$
+          json_path_pattern: tides.spec.json
           send_comment: true
           clear_comments: true
       - name: Validate other schema

--- a/.github/workflows/validate_schemas.yml
+++ b/.github/workflows/validate_schemas.yml
@@ -11,12 +11,14 @@ jobs:
       - name: Validate Data Package schema
         uses: snapcart/json-schema-validator@v1.0.0
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           json_schema: "https://specs.frictionlessdata.io/schemas/data-package.json"
-          json_path_pattern: ^spec\/tides.spec.json$
+          json_path_pattern: ^spec/tides\.spec\.json$
           send_comment: true
           clear_comments: true
       - name: Validate other schema
         uses: snapcart/json-schema-validator@v1.0.0
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           json_schema: "https://specs.frictionlessdata.io/schemas/table-schema.json"
-          json_path_pattern: ^spec\/.*\.schema.json$
+          json_path_pattern: ^spec/.*\.schema\.json$

--- a/.github/workflows/validate_table_schemas.yml
+++ b/.github/workflows/validate_table_schemas.yml
@@ -1,0 +1,24 @@
+name: Validate Frictionless Table Schemas for Spec
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'spec/*.spec.json$'
+      - '!spec/tides.spec.json'
+
+jobs:
+  validate_tables:
+    name: Validate other schema
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate Table schema
+        uses: snapcart/json-schema-validator@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          json_schema: "https://specs.frictionlessdata.io/schemas/table-schema.json"
+          json_path_pattern: ^spec/.*\.schema\.json$
+          send_comment: true
+          clear_comments: true

--- a/.github/workflows/validate_tables_noop.yml
+++ b/.github/workflows/validate_tables_noop.yml
@@ -12,4 +12,4 @@ jobs:
   validate_tables:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "no validation required"'
+      - run: 'echo "no changes to table schemas: no validation required"'

--- a/.github/workflows/validate_tables_noop.yml
+++ b/.github/workflows/validate_tables_noop.yml
@@ -1,0 +1,15 @@
+name: Validate Frictionless Table Schemas for Spec
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '!spec/*.spec.json$'
+      - '!spec/tides.spec.json$'
+
+jobs:
+  validate_tables:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "no validation required"'


### PR DESCRIPTION
 - add token key to jsonschema validator action
 - run validation only on pull-requests, works around <https://github.com/snapcart/json-schema-validator/issues/2>
 - specify python-version for setup-python as '3.x' (latest stable) to use the `cache` feature, see <https://github.com/actions/setup-python/issues/475>
 - use path constraints on validation workflows and split
   - split table spec validation from data package validation to run the correct validation depending on the contents of the PR
   - add `_noop` variants, so that validations succeed if no files match the path constraints (to allow PR merging), see <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks>
