### PR TITLE
Fix redirects with files that moved into docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,6 @@ mkdocs-jupyter
 mkdocs-macros-plugin
 mkdocs-material
 mkdocs-mermaid2-plugin
-mkdocs-redirect
+mkdocs-redirects
 pandas
 tabulate

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,6 @@ mkdocs-jupyter
 mkdocs-macros-plugin
 mkdocs-material
 mkdocs-mermaid2-plugin
+mkdocs-redirect
 pandas
 tabulate

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,13 @@ plugins:
         theme: |
             ^(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light'
         securityLevel: 'loose'
+  - redirects:
+      redirect_maps: #original relative to /docs : redirect target
+        '../architecture.md': 'architecture.md'
+        '../CODE_OF_CONDUCT.md': 'CODE_OF_CONDUCT.md'
+        '../contributing.md': 'contributing.md'
   - search
+  
 
 extra_javascript:
   - https://unpkg.com/mermaid/dist/mermaid.min.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ plugins:
         '../architecture.md': 'architecture.md'
         '../CODE_OF_CONDUCT.md': 'CODE_OF_CONDUCT.md'
         '../contributing.md': 'contributing.md'
+        '../contributors.md': 'contributors.md'
   - search
   
 


### PR DESCRIPTION
This Pull Request uses mkdocs-redirects to fix relative links for files that move from the main repo directory to the `/docs` directory. 


Closes #52 