### PR TITLE
documentation enhancement omnibus PR of 2022

### DIFF
--- a/spec/devices.schema.json
+++ b/spec/devices.schema.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "train_car_id",
-      "title": "ID referencing train_car.train_car_id",
+      "title": "ID referencing train_cars.train_car_id",
       "type": "string",
       "description": "Identifies the train car or asset on which the device is located. May be null if the device is at a stop or station or if the Train_cars file is not used."
     },
@@ -86,5 +86,6 @@
     }
   ],
   "name": "devices.schema.json",
-  "description": "Measurement devices, such as AVL, APC, and AFC devices, associated with vehicles or stops or stations."
+  "description": "Measurement devices, such as AVL, APC, and AFC devices, associated with vehicles or stops or stations.",
+  "_table_type": "Supporting"
 }

--- a/spec/fare_transactions.schema.json
+++ b/spec/fare_transactions.schema.json
@@ -216,5 +216,6 @@
     }
   ],
   "name": "fare_transactions.schema.json",
-  "description": "Timestamped fare transaction, associated with devices."
+  "description": "Timestamped fare transaction, associated with devices.",
+  "_table_type": "Event"
 }

--- a/spec/operators.schema.json
+++ b/spec/operators.schema.json
@@ -17,5 +17,6 @@
     }
   ],
   "name": "operators.schema.json",
-  "description": "Personnel who operate vehicles."
+  "description": "Personnel who operate vehicles.",
+  "_table_type": "Supporting"
 }

--- a/spec/passenger_events.schema.json
+++ b/spec/passenger_events.schema.json
@@ -95,7 +95,7 @@
     {
       "name": "train_car_id",
       "type": "string",
-      "title": "ID referencing train_car.train_car_id",
+      "title": "ID referencing train_cars.train_car_id",
       "description": "Identifies the train car."
     },
     {

--- a/spec/passenger_events.schema.json
+++ b/spec/passenger_events.schema.json
@@ -150,5 +150,6 @@
     }
   ],
   "name": "passenger_events.schema.json",
-  "description": "Timestamped passenger-related events, including boardings and alightings."
+  "description": "Timestamped passenger-related events, including boardings and alightings.",
+  "_table_type": "Event"
 }

--- a/spec/station_activities.schema.json
+++ b/spec/station_activities.schema.json
@@ -220,5 +220,6 @@
     }
   ],
   "name": "station_activities.schema.json",
-  "description": "Summarized transactions, entries, and exits by stop or station and time period for each service date (for events not associated with a trip)."
+  "description": "Summarized transactions, entries, and exits by stop or station and time period for each service date (for events not associated with a trip).",
+  "_table_type": "Summary"
 }

--- a/spec/stop_visits.schema.json
+++ b/spec/stop_visits.schema.json
@@ -358,5 +358,6 @@
     }
   ],
   "name": "stop_visits.schema.json",
-  "description": "Summarized boarding, alighting, arrival, departure, and other events (kneel engaged, ramp deployed, etc.) by trip and stop for each service date."
+  "description": "Summarized boarding, alighting, arrival, departure, and other events (kneel engaged, ramp deployed, etc.) by trip and stop for each service date.",
+  "_table_type": "Summary"
 }

--- a/spec/stop_visits.schema.json
+++ b/spec/stop_visits.schema.json
@@ -22,8 +22,8 @@
     {
       "name": "trip_id_performed",
       "type": "string",
-      "title": "ID referencing GTFS trips_performed.trip_id_performed",
-      "description": "Identifies the trip performed References GTFS",
+      "title": "ID referencing trips_performed.trip_id_performed",
+      "description": "Identifies the trip performed",
       "constraints": {
         "required": true
       }

--- a/spec/train_cars.schema.json
+++ b/spec/train_cars.schema.json
@@ -76,5 +76,6 @@
     }
   ],
   "name": "train_cars.schema.json",
-  "description": "Assets that comprise vehicles, such as train cars, with descriptive information."
+  "description": "Assets that comprise vehicles, such as train cars, with descriptive information.",
+  "_table_type": "Supporting"
 }

--- a/spec/trips_performed.schema.json
+++ b/spec/trips_performed.schema.json
@@ -174,5 +174,6 @@
     }
   ],
   "name": "trips_performed.schema.json",
-  "description": "Trips performed for each service date."
+  "description": "Trips performed for each service date.",
+  "_table_type": "Summary"
 }

--- a/spec/vehicle_locations.schema.json
+++ b/spec/vehicle_locations.schema.json
@@ -201,5 +201,6 @@
     }
   ],
   "name": "vehicle_locations.schema.json",
-  "description": "Timestamped vehicle locations and speeds."
+  "description": "Timestamped vehicle locations and speeds.",
+  "_table_type": "Event"
 }

--- a/spec/vehicle_train_cars.schema.json
+++ b/spec/vehicle_train_cars.schema.json
@@ -21,7 +21,7 @@
     {
       "name": "train_car_id",
       "type": "string",
-      "title": "ID referencing train_car.train_car_id",
+      "title": "ID referencing train_cars.train_car_id",
       "description": "Identifies a train car or an asset that is a component of the vehicle.",
       "constraints": {
         "required": true

--- a/spec/vehicle_train_cars.schema.json
+++ b/spec/vehicle_train_cars.schema.json
@@ -65,5 +65,6 @@
     }
   ],
   "name": "vehicle_train_cars.schema.json",
-  "description": "Relationships between assets and vehicles."
+  "description": "Relationships between assets and vehicles.",
+  "_table_type": "Supporting"
 }

--- a/spec/vehicles.schema.json
+++ b/spec/vehicles.schema.json
@@ -74,5 +74,6 @@
     }
   ],
   "name": "vehicles.schema.json",
-  "description": "Vehicles, including buses and train consists, with descriptive information."
+  "description": "Vehicles, including buses and train consists, with descriptive information.",
+  "_table_type": "Supporting"
 }


### PR DESCRIPTION
This does more than one thing, but they were all connected to improving documentation

- group spec tables by table type (Event, Summary, Supporting)
- sort tables alphabetically
- title case for table titles
- add table description
- add primary key
- add links to GTFS pages referenced
- add links for internal references (foreign IDs)
- add links for rdfTypes

additionally, to make these features function properly, i made the following changes to the spec:

- add a private `_table_type` property (Event, Summary or Supporting)
- fix typo in references to `train_car` to `train_cars`
- change a reference to GTFS trips_performed to an internal reference to the trips_performed table
