### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ indent_size = 4
 [{.git*,Makefile}]
 indent_style = tab
 
+[{COMMIT_EDITMSG,MERGE_MSG,SQUASH_MSG}]
+max_line_length = 72
+
 [**.md]
 # double whitespace at end of line
 # denotes a line break in Markdown

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[{.git*,Makefile}]
+indent_style = tab
+
+[**.md]
+# double whitespace at end of line
+# denotes a line break in Markdown
+trim_trailing_whitespace = false
+x-soft-wrap-text = true
+
+[*.json]
+insert_final_newline = ignore
+
+[*{.ini,.flake8}]
+indent_size = 4
+
+[*.yml]


### PR DESCRIPTION
Uses typical defaults and de facto standards already in place in this repo.

Closes #54 