### PR TITLE
disable edit links in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: "Transit ITS Data Exchange (TIDES) Data Specification Suite"
 site_url: https://TIDES-transit.github.io/TIDES
 repo_url: https://github.com/TIDES-transit/TIDES
-edit_uri: edit/main/docs
+edit_uri: ""
 
 theme:
   name: material
@@ -37,7 +37,6 @@ plugins:
         '../CONTRIBUTING.md': 'CONTRIBUTING.md'
         '../contributors.md': 'contributors.md'
   - search
-
 
 extra_javascript:
   - https://unpkg.com/mermaid/dist/mermaid.min.js


### PR DESCRIPTION
closes #63

I had to disable the check-yaml pre-commit hook, due to the following error, which seems totally unrelated:

`could not determine a constructor for the tag 'tag:yaml.org,2002:python/name:mermaid2.fence_mermaid'
  in "mkdocs.yml", line 61, column 19`