### PR TITLE
fix unintended foreign key dependencies

### DIFF
--- a/spec/devices.schema.json
+++ b/spec/devices.schema.json
@@ -62,7 +62,7 @@
       "description": "Indicates the location of a device on the vehicle or at a station. For example:\nFront door.\nBack door.\nEntrance (not located on a vehicle).\nExit (not located on a vehicle).\nEntrance/exit (not located on a vehicle).\nOther."
     }
   ],
-  "foreignKeys": [
+  "foreignReferences": [
     {
       "fields": "stop_id",
       "reference": {

--- a/spec/fare_transactions.schema.json
+++ b/spec/fare_transactions.schema.json
@@ -171,7 +171,7 @@
       "description": "Stored value remaining on an account after the transaction is made."
     }
   ],
-  "foreignKeys": [
+  "foreignReferences": [
     {
       "fields": "trip_id_performed",
       "reference": {

--- a/spec/passenger_events.schema.json
+++ b/spec/passenger_events.schema.json
@@ -105,7 +105,7 @@
       "description": "Identifies the stop the vehicle is serving. References GTFS"
     }
   ],
-  "foreignKeys": [
+  "foreignReferences": [
     {
       "fields": "trip_id_performed",
       "reference": {

--- a/spec/station_activities.schema.json
+++ b/spec/station_activities.schema.json
@@ -210,7 +210,7 @@
       }
     }
   ],
-  "foreignKeys": [
+  "foreignReferences": [
     {
       "fields": "stop_id",
       "reference": {

--- a/spec/stop_visits.schema.json
+++ b/spec/stop_visits.schema.json
@@ -334,7 +334,7 @@
       }
     }
   ],
-  "foreignKeys": [
+  "foreignReferences": [
     {
       "fields": "trip_id_performed",
       "reference": {

--- a/spec/trips_performed.schema.json
+++ b/spec/trips_performed.schema.json
@@ -157,7 +157,7 @@
       }
     }
   ],
-  "foreignKeys": [
+  "foreignReferences": [
     {
       "fields": "vehicle_id",
       "reference": {

--- a/spec/vehicle_locations.schema.json
+++ b/spec/vehicle_locations.schema.json
@@ -177,7 +177,7 @@
       }
     }
   ],
-  "foreignKeys": [
+  "foreignReferences": [
     {
       "fields": "trip_id_performed",
       "reference": {

--- a/spec/vehicle_train_cars.schema.json
+++ b/spec/vehicle_train_cars.schema.json
@@ -41,7 +41,7 @@
       "description": "Identifies an operator (person). If possible, this should match other internal agency operator IDs."
     }
   ],
-  "foreignKeys": [
+  "foreignReferences": [
     {
       "fields": "vehicle_id",
       "reference": {


### PR DESCRIPTION
This pull request addresses part 2 of issue #77 by using `foreignKeys` instead of `foreignReferences` 

## Context
Using `foreignKeys` in  the spec creates a dependency to another file, which is not the intention. Instead, foreign keys were intended to document optional relationships between files. The existing behavior prevents sample datasets from validating. For example, when providing a `vehicle_locations` file, but not also including `devices` and `train_cars`.

## Options discussed:

- Change the behavior of the validator to change `foreignKeys` from enforced to informational.
- Add an `enforced` attribute to `foreignKeys` so the validator can determine when to enforce the relationship.
- **This PR:** Use a custom property, e.g., `foreignReferences`.

The first two options would require either changes to the existing validator, or forking the validator and maintaining our own. The last option is the easiest, as it requires no changes to the validator, no fork, and has the additional benefit of avoiding language that has a specific and conflicting meaning in databases.

## Decision
Use `foreignReferences` instead of `foreignKeys` in frictionless schema.

## Implementation
The `foreignKeys` property wasn't used anywhere in our documentation pipeline, as of yet, so this is merely a change to the frictionless schemas. 
