### PR TITLE
Support >24 hour service clocks

### DIFF
--- a/spec/fare_transactions.schema.json
+++ b/spec/fare_transactions.schema.json
@@ -25,8 +25,8 @@
     },
     {
       "name": "timestamp",
-      "type": "time",
-      "description": "Recorded event time, including for transactions that may be aggregated values associated with a trip or vehicle.",
+      "type": "datetime",
+      "description": "Recorded event timestamp, including for transactions that may be aggregated values associated with a trip or vehicle.",
       "constraints": {
         "required": true
       }

--- a/spec/passenger_events.schema.json
+++ b/spec/passenger_events.schema.json
@@ -25,8 +25,8 @@
     },
     {
       "name": "timestamp",
-      "type": "time",
-      "description": "Recorded event time.",
+      "type": "datetime",
+      "description": "Recorded event timestamp.",
       "constraints": {
         "required": true
       }

--- a/spec/stop_visits.schema.json
+++ b/spec/stop_visits.schema.json
@@ -68,23 +68,23 @@
     },
     {
       "name": "schedule_arrival_time",
-      "type": "time",
-      "description": "Scheduled time at which the vehicle arrives at a stop. References GTFS"
+      "type": "datetime",
+      "description": "Scheduled timestamp at which the vehicle arrives at a stop. References GTFS"
     },
     {
       "name": "schedule_departure_time",
-      "type": "time",
-      "description": "Scheduled time at which the vehicle departs from a stop. References GTFS"
+      "type": "datetime",
+      "description": "Scheduled timestamp at which the vehicle departs from a stop. References GTFS"
     },
     {
       "name": "actual_arrival_time",
-      "type": "time",
-      "description": "Time at which the vehicle arrives at a stop."
+      "type": "datetime",
+      "description": "Timestamp at which the vehicle arrives at a stop."
     },
     {
       "name": "actual_departure_time",
-      "type": "time",
-      "description": "Time at which the vehicle departs from a stop."
+      "type": "datetime",
+      "description": "Timestamp at which the vehicle departs from a stop."
     },
     {
       "name": "distance",
@@ -136,13 +136,13 @@
     },
     {
       "name": "door_open",
-      "type": "time",
-      "description": "Time at which the doors opened."
+      "type": "datetime",
+      "description": "Timestamp at which the doors opened."
     },
     {
       "name": "door_close",
-      "type": "time",
-      "description": "Time at which the doors closed."
+      "type": "datetime",
+      "description": "Timestamp at which the doors closed."
     },
     {
       "name": "door_status",

--- a/spec/trips_performed.schema.json
+++ b/spec/trips_performed.schema.json
@@ -108,23 +108,23 @@
     },
     {
       "name": "schedule_trip_start",
-      "type": "time",
+      "type": "datetime",
       "description": "Scheduled departure time from the trip’s origin."
     },
     {
       "name": "schedule_trip_end",
-      "type": "time",
-      "description": "Scheduled end time at the trip’s destination."
+      "type": "datetime",
+      "description": "Scheduled end timestamp at the trip’s destination."
     },
     {
       "name": "actual_trip_start",
-      "type": "time",
-      "description": "Time at which the vehicle departed its origin."
+      "type": "datetime",
+      "description": "Timestamp at which the vehicle departed its origin."
     },
     {
       "name": "actual_trip_end",
-      "type": "time",
-      "description": "Time at which the vehicle arrived at its destination."
+      "type": "datetime",
+      "description": "Timestamp at which the vehicle arrived at its destination."
     },
     {
       "name": "in_service",

--- a/spec/vehicle_locations.schema.json
+++ b/spec/vehicle_locations.schema.json
@@ -25,8 +25,8 @@
     },
     {
       "name": "timestamp",
-      "type": "time",
-      "description": "Recorded event time.",
+      "type": "datetime",
+      "description": "Recorded event timestamp.",
       "constraints": {
         "required": true
       }

--- a/spec/vehicles.schema.json
+++ b/spec/vehicles.schema.json
@@ -17,13 +17,13 @@
     },
     {
       "name": "vehicle_start",
-      "type": "time",
-      "description": "The time at which the vehicle or train consist is first in operation (i.e., when the consist has been created). Required if Train_car is used."
+      "type": "datetime",
+      "description": "The timestamp at which the vehicle or train consist is first in operation (i.e., when the consist has been created). Required if Train_car is used."
     },
     {
       "name": "vehicle_end",
-      "type": "time",
-      "description": "The time at which the vehicle or train consist no longer exists (i.e., the consist is separated or modified). Only used if Train_car is used."
+      "type": "datetime",
+      "description": "The timestamp at which the vehicle or train consist no longer exists (i.e., the consist is separated or modified). Only used if Train_car is used."
     },
     {
       "name": "model_name",


### PR DESCRIPTION
This PR changes all `time` fields to `datetime`, and all instances of 'time' in the field description to 'timestamp'.

Use of `datetime` instead of `integer` keeps fields human readable and avoids some ambiguities around daylight savings time.

This PR does not rename fields, though that may also be desirable, e.g., `date` to `service_date`, or `timestamp` to `event_timestamp`.

Closes #31
