### PR TITLE
add optional count field

### DIFF
--- a/spec/passenger_events.schema.json
+++ b/spec/passenger_events.schema.json
@@ -103,6 +103,15 @@
       "type": "string",
       "title": "ID referencing GTFS stops.stop_id",
       "description": "Identifies the stop the vehicle is serving. References GTFS"
+    },
+    {
+      "name": "count",
+      "type": "integer",
+      "title": "Event count",
+      "description": "Count for this event, e.g., 3 for a Passenger Boarding event with 3 boardings, default is  `1`",
+      "constraints": {
+        "minimum": 0
+      }
     }
   ],
   "foreignReferences": [


### PR DESCRIPTION
Adds `count` to the passenger_events table.

I set the minimum to 0, but since the default is 1 and it's not clear what 0 would mean, it should probably be changed to 1.

Closes #73