### PR TITLE
Fixed fields clashing with SQL keywords

### DIFF
--- a/spec/devices.schema.json
+++ b/spec/devices.schema.json
@@ -57,7 +57,7 @@
       "description": "Model of the device as specified by the vendor."
     },
     {
-      "name": "location",
+      "name": "device_location",
       "type": "string",
       "description": "Indicates the location of a device on the vehicle or at a station. For example:\nFront door.\nBack door.\nEntrance (not located on a vehicle).\nExit (not located on a vehicle).\nEntrance/exit (not located on a vehicle).\nOther."
     }

--- a/spec/fare_transactions.schema.json
+++ b/spec/fare_transactions.schema.json
@@ -16,7 +16,7 @@
       }
     },
     {
-      "name": "date",
+      "name": "service_date",
       "type": "date",
       "description": "Service date. References GTFS",
       "constraints": {
@@ -24,7 +24,7 @@
       }
     },
     {
-      "name": "timestamp",
+      "name": "event_timestamp",
       "type": "datetime",
       "description": "Recorded event timestamp, including for transactions that may be aggregated values associated with a trip or vehicle.",
       "constraints": {

--- a/spec/passenger_events.schema.json
+++ b/spec/passenger_events.schema.json
@@ -16,7 +16,7 @@
       }
     },
     {
-      "name": "date",
+      "name": "service_date",
       "type": "date",
       "description": "Service date. References GTFS",
       "constraints": {
@@ -24,7 +24,7 @@
       }
     },
     {
-      "name": "timestamp",
+      "name": "event_timestamp",
       "type": "datetime",
       "description": "Recorded event timestamp.",
       "constraints": {
@@ -111,7 +111,7 @@
       "description": "Identifies the unique stop-path for a trip, may be distinct from GTFS shapes.shape_id"
     },
     {
-      "name": "count",
+      "name": "event_count",
       "type": "integer",
       "title": "Event count",
       "description": "Count for this event, e.g., 3 for a Passenger Boarding event with 3 boardings, default is  `1`",

--- a/spec/station_activities.schema.json
+++ b/spec/station_activities.schema.json
@@ -12,7 +12,7 @@
   ],
   "fields": [
     {
-      "name": "date",
+      "name": "service_date",
       "type": "date",
       "description": "Service date",
       "constraints": {

--- a/spec/stop_visits.schema.json
+++ b/spec/stop_visits.schema.json
@@ -12,7 +12,7 @@
   ],
   "fields": [
     {
-      "name": "date",
+      "name": "service_date",
       "type": "date",
       "description": "Service date. References GTFS indirectly via calendars.txt and calendar_dates.txt",
       "constraints": {
@@ -68,7 +68,7 @@
       "description": "Identifies the stop. References GTFS"
     },
     {
-      "name": "checkpoint",
+      "name": "timepoint",
       "type": "boolean",
       "description": "Indicates if the stop should be used for evaluating schedule adherence, on-time performance, and other KPIs. This could be populated to match the GTFS “timepoint” field."
     },
@@ -133,7 +133,7 @@
       }
     },
     {
-      "name": "load",
+      "name": "vehicle_load",
       "type": "integer",
       "description": "Number of riders on the vehicle when departing the stop.",
       "constraints": {

--- a/spec/stop_visits.schema.json
+++ b/spec/stop_visits.schema.json
@@ -133,7 +133,7 @@
       }
     },
     {
-      "name": "vehicle_load",
+      "name": "departure_load",
       "type": "integer",
       "description": "Number of riders on the vehicle when departing the stop.",
       "constraints": {

--- a/spec/trips_performed.schema.json
+++ b/spec/trips_performed.schema.json
@@ -10,7 +10,7 @@
   ],
   "fields": [
     {
-      "name": "date",
+      "name": "service_date",
       "type": "date",
       "description": "Service date. References GTFS",
       "constraints": {

--- a/spec/vehicle_locations.schema.json
+++ b/spec/vehicle_locations.schema.json
@@ -16,7 +16,7 @@
       }
     },
     {
-      "name": "date",
+      "name": "service_date",
       "type": "date",
       "description": "Service date. References GTFS",
       "constraints": {
@@ -24,7 +24,7 @@
       }
     },
     {
-      "name": "timestamp",
+      "name": "event_timestamp",
       "type": "datetime",
       "description": "Recorded event timestamp.",
       "constraints": {

--- a/spec/vehicle_train_cars.schema.json
+++ b/spec/vehicle_train_cars.schema.json
@@ -28,7 +28,7 @@
       }
     },
     {
-      "name": "order",
+      "name": "train_car_order",
       "type": "integer",
       "description": "The assigned order of the train car or asset within the vehicle.",
       "constraints": {


### PR DESCRIPTION
Updates several field names to avoid SQL keywords in common databases:

Schema | Current Field Name | Proposed Field Name
-- | -- | --
fare_transactions | date | service_date
fare_transactions | timestamp | event_timestamp
passenger_events | date | service_date
passenger_events | timestamp | event_timestamp
passenger_events | count | event_count
vehicle_locations | date | service_date
vehicle_locations | timestamp | event_timestamp
station_activities | date | service_date
stop_visits | date | service_date
stop_visits | checkpoint | timepoint
stop_visits | load | vehicle_load
trips_performed | date | service_date
devices | location | device_location
vehicle_train_cars | order | train_car_order

Closes #82

