### PR TITLE
fix primary key fields

### DIFF
--- a/spec/station_activities.schema.json
+++ b/spec/station_activities.schema.json
@@ -1,6 +1,6 @@
 {
   "primaryKey": [
-    "date",
+    "service_date",
     "stop_id",
     "time_period_start",
     "time_period_end"

--- a/spec/stop_visits.schema.json
+++ b/spec/stop_visits.schema.json
@@ -1,6 +1,6 @@
 {
   "primaryKey": [
-    "date",
+    "service_date",
     "trip_id_performed",
     "stop_sequence",
     "vehicle_id"

--- a/spec/trips_performed.schema.json
+++ b/spec/trips_performed.schema.json
@@ -1,6 +1,6 @@
 {
   "primaryKey": [
-    "date",
+    "service_date",
     "trip_id_performed"
   ],
   "missingValues": [


### PR DESCRIPTION
change `date` to `service_date` in primary field definitions.

Closes #117
