### PR TITLE
fix path specs in GitHub Actions validation workflows

### DIFF
--- a/.github/workflows/validate_package_noop.yml
+++ b/.github/workflows/validate_package_noop.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - '!spec/tides.spec.json$'
+      - '!spec/tides.spec.json'
 
 jobs:
   validate_data_package:

--- a/.github/workflows/validate_package_schema.yml
+++ b/.github/workflows/validate_package_schema.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'spec/tides.spec.json$'
+      - 'spec/tides.spec.json'
 
 jobs:
   validate_data_package:

--- a/.github/workflows/validate_table_schemas.yml
+++ b/.github/workflows/validate_table_schemas.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'spec/*.schema.json$'
+      - 'spec/*.schema.json'
       - '!spec/tides.spec.json'
 
 jobs:

--- a/.github/workflows/validate_tables_noop.yml
+++ b/.github/workflows/validate_tables_noop.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     paths:
-      - '!spec/*.schema.json$'
-      - '!spec/tides.spec.json$'
+      - '!spec/*.schema.json'
+      - '!spec/tides.spec.json'
 
 jobs:
   validate_tables:


### PR DESCRIPTION
GitHub does not support the grep '$' operator, so no validations have run on spec changes.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

This needs to merge before any other PRs can be merged, so that the appropriate checks can run.

Re #120