### PR TITLE
Fix mermaid

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ watch:
   - README.md
 
 extra_javascript:
-  - https://unpkg.com/mermaid/dist/mermaid.min.js
+  - https://unpkg.com/mermaid@9.4.3/dist/mermaid.min.js
 
 extra_css:
   - https://use.fontawesome.com/releases/v5.13.0/css/all.css


### PR DESCRIPTION
Pins mermaid to version 9.4.3, to avoid incompatibility between version 10 and mkdocs. 

There's an open issue to make version 10 work with mkdocs.
https://github.com/fralau/mkdocs-mermaid2-plugin/issues/70

There's a work-around in the above issue where you create a new javascript file that loads the ESM module of mermaid v10. I'm open to that as well.