### PR TITLE
Fix frictionless table schema url

### DIFF
--- a/.github/workflows/validate_table_schemas.yml
+++ b/.github/workflows/validate_table_schemas.yml
@@ -18,7 +18,7 @@ jobs:
         uses: snapcart/json-schema-validator@v1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          json_schema: "https://specs.frictionlessdata.io/schemas/table-schema.json"
+          json_schema: "https://github.com/frictionlessdata/specs/blob/master/schemas/table-schema.json"
           json_path_pattern: ^spec/.*\.schema\.json$
           send_comment: true
           clear_comments: true


### PR DESCRIPTION
Should fix failing validations on pull-requests because schema was unavailable.

See table schema validation failure [here](https://github.com/TIDES-transit/TIDES/actions/runs/4833928906/jobs/8614537603#step:4:18)

Closes #133