### PR TITLE
Adds description about consistency of trip_ids

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,3 +82,9 @@ graph LR;
     click passenger_events "../tables/#passenger-events"
     click fare_transactions "../tables/#fare-transactions"
 ```
+
+!!! tip "Relationship of `trip_id_performed` to GTFS Schedule `trip_id`"
+
+    `trip_id_performed` in TIDES and `trip_id` in GTFS Schedule should be consistent when a performed trip exists in the published GTFS Schedule. 
+
+    If a trip does not exist in the published GTFS Schedule, `trip_id` values in TIDES do not have any assumed relationship. 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,8 +83,8 @@ graph LR;
     click fare_transactions "../tables/#fare-transactions"
 ```
 
-!!! tip "Relationship of `trip_id_performed` to GTFS Schedule `trip_id`"
+!!! tip "Relationship of `trip_id_scheduled` to GTFS Schedule `trip_id`"
 
-    `trip_id_performed` in TIDES and `trip_id` in GTFS Schedule should be consistent when a performed trip exists in the published GTFS Schedule. 
+    `trip_id_scheduled` in TIDES and `trip_id` in GTFS Schedule should be consistent when a performed trip exists in the published GTFS Schedule. 
 
     If a trip does not exist in the published GTFS Schedule, `trip_id` values in TIDES do not have any assumed relationship. 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,4 +87,4 @@ graph LR;
 
     `trip_id_scheduled` in TIDES and `trip_id` in GTFS Schedule should be consistent when a performed trip exists in the published GTFS Schedule. 
 
-    If a trip does not exist in the published GTFS Schedule, `trip_id` values in TIDES do not have any assumed relationship. 
+    If a trip does not exist in the published GTFS Schedule, `trip_id_scheduled` values in TIDES do not have any assumed relationship with GTFS. 

--- a/spec/fare_transactions.schema.json
+++ b/spec/fare_transactions.schema.json
@@ -69,7 +69,7 @@
       "name": "trip_id_performed",
       "type": "string",
       "title": "ID referencing trips_performed.trip_id_performed",
-      "description": "Identifies the trip performed. May be null if the fare collection device is NOT located on a vehicle. May be null if on a vehicle but trip-level data is unavailable, in which case the data would be associated with the vehicle. If this trip was published in GTFS Schedule, this value should be consistent with the GTFS `trip_id`"
+      "description": "Identifies the trip performed. May be null if the fare collection device is NOT located on a vehicle. May be null if on a vehicle but trip-level data is unavailable, in which case the data would be associated with the vehicle."
     },
     {
       "name": "pattern_id",

--- a/spec/fare_transactions.schema.json
+++ b/spec/fare_transactions.schema.json
@@ -69,7 +69,7 @@
       "name": "trip_id_performed",
       "type": "string",
       "title": "ID referencing trips_performed.trip_id_performed",
-      "description": "Identifies the trip performed. May be null if the fare collection device is NOT located on a vehicle. May be null if on a vehicle but trip-level data is unavailable, in which case the data would be associated with the vehicle."
+      "description": "Identifies the trip performed. May be null if the fare collection device is NOT located on a vehicle. May be null if on a vehicle but trip-level data is unavailable, in which case the data would be associated with the vehicle. If this trip was published in GTFS Schedule, this value should be consistent with the GTFS `trip_id`"
     },
     {
       "name": "pattern_id",

--- a/spec/trips_performed.schema.json
+++ b/spec/trips_performed.schema.json
@@ -20,7 +20,7 @@
     {
       "name": "trip_id_performed",
       "type": "string",
-      "description": "Uniquely identifies the trip performed. If this trip was published in GTFS Schedule, this value should be consistent with the GTFS `trip_id`.",
+      "description": "Uniquely identifies the trip performed.",
       "constraints": {
         "required": true
       }
@@ -38,7 +38,7 @@
       "name": "trip_id_scheduled",
       "type": "string",
       "title": "ID referencing GTFS trips.trip_id",
-      "description": "Identifies the scheduled trip associated with the trip performed. One scheduled trip may be associated with multiple operated trips, or an operated trip may not be associated with a scheduled trip. References GTFS.  If this trip was published in GTFS Schedule, this value should be consistent with the GTFS `trip_id`."
+      "description": "Identifies the scheduled trip associated with the trip performed. One scheduled trip may be associated with multiple operated trips, or an operated trip may not be associated with a scheduled trip. References GTFS.  If this trip was published in GTFS Schedule, this value should be consistent with the GTFS `trip_id`.  If this trip was not scheduled, the value should be Null."
     },
     {
       "name": "route_id",

--- a/spec/trips_performed.schema.json
+++ b/spec/trips_performed.schema.json
@@ -20,7 +20,7 @@
     {
       "name": "trip_id_performed",
       "type": "string",
-      "description": "Uniquely identifies the trip performed. If this trip was published in GTFS Schedule, this value should be consistent with the GTFS `trip_id",
+      "description": "Uniquely identifies the trip performed. If this trip was published in GTFS Schedule, this value should be consistent with the GTFS `trip_id`.",
       "constraints": {
         "required": true
       }
@@ -38,7 +38,7 @@
       "name": "trip_id_scheduled",
       "type": "string",
       "title": "ID referencing GTFS trips.trip_id",
-      "description": "Identifies the scheduled trip associated with the trip performed. One scheduled trip may be associated with multiple operated trips, or an operated trip may not be associated with a scheduled trip. References GTFS"
+      "description": "Identifies the scheduled trip associated with the trip performed. One scheduled trip may be associated with multiple operated trips, or an operated trip may not be associated with a scheduled trip. References GTFS.  If this trip was published in GTFS Schedule, this value should be consistent with the GTFS `trip_id`."
     },
     {
       "name": "route_id",

--- a/spec/trips_performed.schema.json
+++ b/spec/trips_performed.schema.json
@@ -20,7 +20,7 @@
     {
       "name": "trip_id_performed",
       "type": "string",
-      "description": "Identifies the trip performed.",
+      "description": "Uniquely identifies the trip performed. If this trip was published in GTFS Schedule, this value should be consistent with the GTFS `trip_id",
       "constraints": {
         "required": true
       }


### PR DESCRIPTION
This PR adds explicit description of the implied relationship between `trip_id` in GTFS and `trip_id_performed` if and when trips exist in both datasets.

Based on discussion for issue #50 