### PR TITLE
Clarify meaning of fare_capped

### DIFF
--- a/spec/fare_transactions.schema.json
+++ b/spec/fare_transactions.schema.json
@@ -153,7 +153,7 @@
     {
       "name": "fare_capped",
       "type": "boolean",
-      "description": "Indicates if fare capping is in effect (fare capping options defined by transit agency).",
+      "description": "Indicates if the fare charged in this transaction was modified by a fare capping policy.",
       "constraints": {
         "required": true
       }


### PR DESCRIPTION
Clarified meaning of `fare_capped` in `fare_transactions`. Resolves #110.