### PR TITLE
Don't run comment action on merge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
         echo "Documentation available at: http://tides-transit.github.io/TIDES/${{ env.Slug }}"
   comment:
     runs-on: ubuntu-latest
-    if: ${{ github.context.event_name }} == "pull_request"
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == false }}
     steps:
       - uses: actions/github-script@v6.4.1
         with:


### PR DESCRIPTION
# Pull Request
When we merged #150, I noticed that the conditions used to generate the docs link comment on PRs were overly broad - the task tried to fire after merge with a then-incorrect URL, which is unnecessary and [causes a CI failure upon merge](https://github.com/TIDES-transit/TIDES/actions/runs/5524648268/jobs/10077228341) that doesn't reflect a "real" issue.

I've reformulated the `if` condition so that the comment action doesn't fire on a merge commit. [I tested this on a personal fork](https://github.com/SorenSpicknall/TIDES/pull/1) and confirmed that A.) the comment action works as expected during pull request events, and B.) it is skipped upon merge.