### PR TITLE
131 specify foreign key relationships that already exist but arent listed explicitly

### DIFF
--- a/.github/workflows/validate_samples.yml
+++ b/.github/workflows/validate_samples.yml
@@ -4,11 +4,11 @@ on:
   push:
     paths:
       - 'samples/*/TIDES/*'
-      - 'spec/*'
+      # - 'spec/*' (TODO: Reinstate once samples folder exists)
   pull_request:
     paths:
       - 'samples/*/TIDES/*'
-      - 'spec/*'
+      # - 'spec/*' (TODO: Reinstate once samples folder exists)
   workflow_dispatch:
   create:
 

--- a/spec/fare_transactions.schema.json
+++ b/spec/fare_transactions.schema.json
@@ -184,10 +184,10 @@
       }
     },
     {
-      "fields": "stop_sequence",
+      "fields": ["service_date", "trip_id_performed", "stop_sequence"],
       "reference": {
         "resource": "stop_times",
-        "fields": "stop_sequence"
+        "fields": ["service_date", "trip_id_performed", "stop_sequence"]
       }
     },
     {

--- a/spec/passenger_events.schema.json
+++ b/spec/passenger_events.schema.json
@@ -132,10 +132,10 @@
       }
     },
     {
-      "fields": "stop_sequence",
+      "fields": ["service_date", "trip_id_performed", "stop_sequence"],
       "reference": {
         "resource": "stop_times",
-        "fields": "stop_sequence"
+        "fields": ["service_date", "trip_id_performed", "stop_sequence"]
       }
     },
     {

--- a/spec/vehicle_locations.schema.json
+++ b/spec/vehicle_locations.schema.json
@@ -189,6 +189,13 @@
       }
     },
     {
+      "fields": ["service_date", "trip_id_performed", "stop_sequence"],
+      "reference": {
+        "resource": "stop_times",
+        "fields": ["service_date", "trip_id_performed", "stop_sequence"]
+      }
+    },
+    {
       "fields": "vehicle_id",
       "reference": {
         "resource": "vehicles",


### PR DESCRIPTION
Partially resolves #131 .  This adds the foreign references that @jaygordon listed as examples, but I have not thoroughly reviewed the repo to find other missing references.  In the TIDES discussion from 2 weeks ago I believe we said that we might be fine saying that this is good enough for the 1.0 milestone, and that other missing references can be added if and when they are discovered.

A question for those more familiar with frictionless: am I following the correct format for a multi-column reference?

This commit works well if we assume that `trip_id_performed` is unique each day *and* that fare transactions from some service date can only correspond to stop visits from the same service date, which is true in most cases.  But there could be an agency that runs through the night, with vehicles simultaneously operating trips of different service dates at round 3 am, and in that case a fare transaction could be from a different service date than the stop visit.  This isn't currently handled by TIDES.