### PR TITLE
allow build-docs if trigger is not pull_request

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build-deploy:
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo


### PR DESCRIPTION
Re-add the if clause, but allow for any non-pull_request trigger.

Closes #168

# Pull Request

Before submitting a pull request, please read [CONTRIBUTING.md](CONTRIBUTING.md).

For spec changes:

- [x] Pull-requests must address an existing issue
- [x] Update relevant documentation.

By contributing to this project, all contributors certify to the Developer Certificate of Origin in [CONTRIBUTING.md](CONTRIBUTING.md#contributor-agreement).
