### PR TITLE
Temporarily pin mike to <2.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mike
+mike<2.0
 mkdocs
 mkdocs-autorefs
 mkdocs-awesome-pages-plugin


### PR DESCRIPTION
Breaking change in mike 2.0 doesn't allow rebase.
This is a quick fix to pin mike to <2.0 to resolve for now. 
This should be fixed in resolving bug report filed in #173
