### PR TITLE
Update CONTRIBUTING.md to refer to governance.

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,13 @@
+# TIDES Contributor License Agreement
+
+By making a contribution to this project, I certify that:
+>  
+> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+>  
+> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+>  
+> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+>  
+> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+>  
+Attribution: This Contributor Agreement is adapted from the node.js project available here: <https://github.com/nodejs/node/blob/main/CONTRIBUTING.md>.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Contributor Covenant Code of Conduct
+# TIDES Code of Conduct
 
 ## Our Pledge
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,36 @@
 # Contributing to TIDES
 
-Thank you for contributing to the TIDES Project. This document defines the roles and process for contributing to the project and documents the governance roles and approach for decision-making.
+Thank you for contributing to the TIDES Project. This document the process for contributing to the project and documents the governance roles and approach for decision-making. Where [TIDES Governance][TIDES-governance] and this document differ, the [TIDES Governance][TIDES-governance] shall take precedence.
 
-## Roles
+[contributor-registration]: https://forms.office.com/Pages/ResponsePage.aspx?id=i_a_3SpIc0WB4P74FWpP0Hpd6kyRp1VEg8rnx5-CwORUMFFGTzBYRktEMkJRWVg4Qlg3SkM0VEJKVi4u
+[TIDES-governance]: https://tides-transit.github.io/TIDES/governance/
+[TIDES-Board]:https://tides-transit.github.io/TIDES/governance/#tides-board-of-directors
+[TIDES-Contributor]:https://tides-transit.github.io/TIDES/governance/#tides-contributor
+[TIDES-Manager]:https://tides-transit.github.io/TIDES/governance/#tides-manager
+[TIDES-Stakeholder]: https://tides-transit.github.io/TIDES/governance/#tides-stakeholder
 
-There are two types of contributors to TIDES:
+## Becoming a TIDES Contributor
 
-* Registered Contributors can create and respond to issues and can generate and comment on pull requests, and
-* All other Stakeholders can create and respond to issues.
+As defined in the [TIDES Governance][TIDES-governance], a [TIDES-Contributor][TIDES-contributor] has the rights to:
 
-All contributors and stakeholders are asked to adhere to the [Code of Conduct](#code-of-conduct).
+- Create issues, discussions, and pull requests in the TIDES repository.
+- Vote in decisions on changes to the TIDES spec and other aspects of TIDES.
 
-To become a registered Contributor, fill out the registration form at [this link][contributor-registration].
+These roles and responsibilities are further detailed in the [TIDES Governance][TIDES-governance] and documents linked to from it.  
+
+Individuals may request to be a Contributor by completing [the registration form][contributor-registration]that includes acknowledgement of the [Contributor Agreement](#tides-contributor-license-agreement) and [Code of Conduct](#tides-code-of-conduct).
 
 ## How to Contribute
 
-Contributions should be offered through GitHub issues and pull requests.
+1. Become a [TIDES Contributor](#becoming-a-tides-contributor)
+2. Follow [setup](#setup) instructions if you'd like to contribute code or provide code reviews.
+3. Offer to help research an issue
+4. Offer to help resolve an issue with a pull-request
+5. Offer to review a pull-request
 
-By making any contribution to the projects, contributors self-certify to the [Contributor Agreement](#contributor-agreement).
+!!! warning
+
+    By making any contribution to the projects, contributors self-certify to the [Contributor Agreement](#tides-contributor-license-agreement).
 
 ### Setup
 
@@ -48,17 +61,17 @@ request, be sure to link the two. There are shortcuts [here](https://docs.github
 
 Use the following guidance in creating and responding to pull requests
 
-* Keep pull requests small and focused. One issue is best.
-* Link Pull Requests to Issues as appropriate.
-* Complete the pull request template as best you can.
-* In order to run all GitHub Actions automations, contributors with adequate permissions (i.e. Registered Contributors) should submit pull requests from a branch on the main repo, rather than from a fork.
+- Keep pull requests small and focused. One issue is best.
+- Link Pull Requests to Issues as appropriate.
+- Complete the pull request template as best you can.
+- In order to run all GitHub Actions automations, contributors with adequate permissions (i.e. Registered Contributors) should submit pull requests from a branch on the main repo, rather than from a fork.
 
 ### Commits
 
 Use the following guidance for commits
 
-* Provide a short, clear title. Capitalize. No period at the end
-* Wrap the body of text at 72 characters
+- Provide a short, clear title. Capitalize. No period at the end
+- Wrap the body of text at 72 characters
 
 ### Continuous Integration / Continuous Deployment
 
@@ -165,21 +178,9 @@ When a change is pushed to the TIDES specification repository, Github Actions de
     if_spec--> architecture.html
     ```
 
-## Contributor Agreement
+## TIDES Contributor License Agreement
 
-By making any contribution to the projects, contributors self-certify to the following Contributor Agreement:
-
-By making a contribution to this project, I certify that:
->  
-> a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
->  
-> b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
->  
-> c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
->  
-> d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
->  
-Attribution: This Contributor Agreement is adapted from the node.js project available here: <https://github.com/nodejs/node/blob/main/CONTRIBUTING.md>.
+By making any contribution to the projects, contributors self-certify to the the [TIDES Contributor Agreement](CLA.md).
 
 ## License to Use
 
@@ -187,78 +188,35 @@ The TIDES specification is licensed under the Apache License 2.0 as defined in <
 
 ## Project Governance
 
-Ahead of Version 1.0 release, the governance for the TIDES specification is being kept limited and lightweight. The governance approach will be revisited as release of Version 1.0 approaches.
+The TIDES Project Governance and the roles within are detailed in the [TIDES-governance][TIDES-governance] documentation.  At this time, the following people fulfill the TIDES roles:
 
-Development of the TIDES specification shall be managed by the following groups:
+### Roles
 
-* [Leadership Group](#leadership-group)
-* [Product Management Team](#product-management-team)
-* [Registered Contributors](#registered-contributors)
-* [All Other Stakeholders](#stakeholder-group)
+- [**TIDES Board**][TIDES-Board]
+    - John Levin, Metro Transit (Minneapolis-St. Paul, MN)
+- **Board Coordinator**: *TBD*
+- [**TIDES Manager**][TIDES-Manager]: *Currently in discussion*
+- **Program Manager**: *TBD*
+- [**TIDES-Contributors**][TIDES-Contributor]: [List of Contributors](contributors.md)
+- [**TIDES-Stakeholders**][TIDES-Stakeholder]: Anyone who has an interest in or could be directly affected by the TIDES specification and tools.
 
-These groups will have the following rights and responsibilities:
+### [GitHub Access Levels](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization)
 
-### Leadership Group
-
-The Leadership Group is responsible for overall direction and decision-making on the project including:
-
-* approval of registered contributors
-* creation, scoping, and management of working groups
-* approval of the final specification for Version 1.0
-* approval of changes to project governance
-
-Leadership Group Members
-
-* John Levin, Metro Transit (Minneapolis-St. Paul, MN)
-
-Leadership Group Member [GitHub Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Admin
-
-### Product Management Team
-
-The Product Management Team (PMT) is responsible for creating and maintaining backbone standards infrastructure, processes, and resources to support the development of the TIDES specification. The PMT will support Leadership in developing, reviewing, and recommending for approval changes to the draft specification. The PMT will support Contributors and Stakeholders in their work on the specification.  
-
-PMT Group Members
-
-* Hunter Owens, Caltrans
-* Jameelah Young, Jarvus Innovations (on behalf of Caltrans)
-* Soren Spicknall, Jarvus Innovations (on behalf of Caltrans)
-* Elizabeth Sall, UrbanLabs LLC (on behalf of Caltrans)
-* Benjamin Bressette, Caltrans
-* Joey Reid, Metro Transit (Minneapolis-St. Paul, MN)
-
-PMT Group Member [GitHub Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Admin
-
-### Registered Contributors
-
-Registered Contributors actively work to develop the TIDES specification. They propose additions, modifications, and improvements to the specification through issues and pull requests in this GitHub repository.
-
-Registered Contributors must request [here][contributor-registration] to be registered in order to gain access. Requests to become a Contributor must be approved by project Leadership.
-
-Registered Contributor Group Members:
-
-The list of registered contributors is maintained in the [contributors.md](contributors.md) file.
-
-Registered Contributor Group [GitHub Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Write
-
-### Stakeholder Group
-
-Stakeholders will be informed about progress on TIDES and given the opportunity to review the specification as it is developed. They may provide comments on the specification by creating or responding to Issues in this repository. Stakeholders are not able to generate or comment on pull requests. To be included as a TIDES Stakeholder, join the TIDES Project Google Group.
-
-Stakeholder Group Membership:
-
-* Members of the TIDES Project Google Group
-* Others who have expressed interest in following progress or contributing to TIDES, but who have not requested to be a registered Contributor
-
-Stakeholder Group [GitHub Access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization): Read/Create Issues (same as general public)
+| **Role**            | **Access Level**   |
+|---------------------|--------------------|
+| Board               | Admin              |
+| Program Manager     | Admin              |
+| Board Coordinator   | Triage             |
+| Manager             | Triage             |
+| Contributor Group   | Triage             |
+| Stakeholder         | Read/Create Issues |
 
 ## Review and Approval Process
 
-Prior to release of Version 1.0 of the specification, the PMT and Leadership will have final approval of all changes. All Contributors are permitted and encouraged to discuss and comment on issues and pull requests and make recommendations for changes to the specification.
+Prior to release of Version 1.0 of the specification, the TIDES Board will have final approval of all changes. All Contributors are permitted and encouraged to discuss and comment on issues and pull requests and make recommendations for changes to the specification.
 
-Leadership will convene a governance group to refine this and decide the approval process for Version 1.0 and the governance and approval process for future revisions to the specification.
+Following v1.0, TIDES will adhere to a change management policy currently in development.
 
-## Code of Conduct
+## TIDES Code of Conduct
 
 Contributors to the TIDES Project are expected to read and follow the [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) for the project.
-
-[contributor-registration]: https://forms.office.com/Pages/ResponsePage.aspx?id=i_a_3SpIc0WB4P74FWpP0Hpd6kyRp1VEg8rnx5-CwORUMFFGTzBYRktEMkJRWVg4Qlg3SkM0VEJKVi4u

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to TIDES
 
-Thank you for contributing to the TIDES Project. This document the process for contributing to the project and documents the governance roles and approach for decision-making. Where [TIDES Governance][TIDES-governance] and this document differ, the [TIDES Governance][TIDES-governance] shall take precedence.
+Thank you for contributing to the TIDES Project. This document outlines the process for contributing to the project and documents the governance roles and approach for decision-making. Where [TIDES Governance][TIDES-governance] and this document differ, the [TIDES Governance][TIDES-governance] shall take precedence.
 
 [contributor-registration]: https://forms.office.com/Pages/ResponsePage.aspx?id=i_a_3SpIc0WB4P74FWpP0Hpd6kyRp1VEg8rnx5-CwORUMFFGTzBYRktEMkJRWVg4Qlg3SkM0VEJKVi4u
 [TIDES-governance]: https://tides-transit.github.io/TIDES/governance/

--- a/contributors.md
+++ b/contributors.md
@@ -2,25 +2,37 @@
 
 *Presented alphabetically by first name*
 
-- [@AztecCyclocross](https://github.com/azteccyclocross)
+- [Jonathan Wade](https://github.com/azteccyclocross)
 - [Benjamin Bressette](https://github.com/benjaminbressette)
+- [Brandon Irvine](https://github.com/underplex)
+- Brendon Hemily
+- [Cecilia Viggiano](https://github.com/ceciliaviggiano)
+- [Chris Alfano](https://github.com/themightychris)
 - [Daniel Patterson](https://github.com/Bikingman)
-- [Diego](https://github.com/diluisi)
+- [Diego Da Silva](https://github.com/diluisi)
+- [Elise Chessman](https://github.com/elisechessman)
 - [Elizabeth Sall](https://github.com/e-lo)
-- [@emma162](https://github.com/emma162)
+- [Emma Patel](https://github.com/emma162)
+- [Erik Jensen](https://github.com/danishwag)
 - [Gabriel Sánchez Martínez](https://github.com/gabriel-korbato)
+- Girogio Ambrosino
 - [Hunter Owens](https://github.com/hunterowens)
 - [Jameelah Young](https://github.com/j-meelah)
+- Jason Adle
 - [Jay Gordon](https://github.com/jaygordon)
 - [Joey Reid](https://github.com/botanize)
 - [John Levin](https://github.com/jlstpaul)
 - [Katrina Kaiser](https://github.com/KatrinaMKaiser)
+- Lina Kulkowski
 - [Michael Eichler](https://github.com/planitmichael)
-- [@mtnsguy](https://github.com/mtnsguy)
+- [Michael Paine](https://github.com/mpaine-act)
+- [James Garner](https://github.com/mtnsguy)
 - [Nisar Ahmed](https://github.com/jewel1965)
 - [Paul Swartz](https://github.com/paulswartz)
 - [Sandy Brennan](https://github.com/SrBrennan12)
+- Sarah Davidson
 - [Soren Spicknall](https://github.com/SorenSpicknall)
 - [Stephan Schindehette](https://github.com/sschindehette)
+- Subu Swayam
 - [Thomas Craig](https://github.com/tsherlockcraig)
 - [Wylie Timmerman](https://github.com/wtimmerman-fitp)

--- a/contributors.md
+++ b/contributors.md
@@ -1,1 +1,26 @@
 # Contributors
+
+*Presented alphabetically by first name*
+
+- [@AztecCyclocross](https://github.com/azteccyclocross)
+- [Benjamin Bressette](https://github.com/benjaminbressette)
+- [Daniel Patterson](https://github.com/Bikingman)
+- [Diego](https://github.com/diluisi)
+- [Elizabeth Sall](https://github.com/e-lo)
+- [@emma162](https://github.com/emma162)
+- [Gabriel Sánchez Martínez](https://github.com/gabriel-korbato)
+- [Hunter Owens](https://github.com/hunterowens)
+- [Jameelah Young](https://github.com/j-meelah)
+- [Jay Gordon](https://github.com/jaygordon)
+- [Joey Reid](https://github.com/botanize)
+- [John Levin](https://github.com/jlstpaul)
+- [Katrina Kaiser](https://github.com/KatrinaMKaiser)
+- [Michael Eichler](https://github.com/planitmichael)
+- [@mtnsguy](https://github.com/mtnsguy)
+- [Nisar Ahmed](https://github.com/jewel1965)
+- [Paul Swartz](https://github.com/paulswartz)
+- [Sandy Brennan](https://github.com/SrBrennan12)
+- [Soren Spicknall](https://github.com/SorenSpicknall)
+- [Stephan Schindehette](https://github.com/sschindehette)
+- [Thomas Craig](https://github.com/tsherlockcraig)
+- [Wylie Timmerman](https://github.com/wtimmerman-fitp)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,9 @@
 # Development
 
-{{ include_file('CONTRIBUTING.md') }}
+{{ include_file_sections( 'CONTRIBUTING.md',exclude_sections=['TIDES Contributor Agreement','TIDES Code of Conduct']) }}
 
 {{ include_file('CODE_OF_CONDUCT.md') }}
+
+{{ include_file('CLA.md') }}
 
 {{ include_file('contributors.md') }}

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -95,7 +95,7 @@ TIDES is governed by a Board of Directors.
 
 ### TIDES Contributor
 
-- Individuals will request to be a Contributor by completing an online form that includes acknowledgement of the Contributor Agreement and TIDES Code of Conduct.
+- Individuals will request to be a Contributor by completing an [online form][contributor-registration] that includes acknowledgement of the Contributor Agreement and TIDES Code of Conduct.
 - A TIDES Contributor has rights to create issues, discussions, and pull requests in the TIDES repository.
 - A TIDES Contributor has rights to vote in decisions on changes to the TIDES spec and other aspects of TIDES.
 
@@ -115,3 +115,5 @@ Documentation, documents, and decisions of the Board will be stored in a TIDES-t
 
 - Initial release of the TIDES Governance document.
 - Establishment of governance principles, roles, policies, and procedures.
+
+[contributor-registration]: https://forms.office.com/Pages/ResponsePage.aspx?id=i_a_3SpIc0WB4P74FWpP0Hpd6kyRp1VEg8rnx5-CwORUMFFGTzBYRktEMkJRWVg4Qlg3SkM0VEJKVi4u

--- a/main.py
+++ b/main.py
@@ -11,13 +11,15 @@ import pandas as pd
 log = logging.getLogger("mkdocs")
 
 FIND_REPLACE = {  # original relative to /docs : redirect target
-    "<CONTRIBUTING.md>": "[Contributing Section](development/#CONTRIBUTING)",
-    "(CODE_OF_CONDUCT.md)": "(development/#CODE_OF_CONDUCT)",
-    "CONTRIBUTING.md)": "development/#CONTRIBUTING)",
+    "<CONTRIBUTING.md>": "[Contributing Section](development/)",
+    "(CODE_OF_CONDUCT.md)": "(development/#tides-code-of-conduct)",
+    "(CLA.md)": "(development/#tides-contributor-license-agreement)",
+    "CONTRIBUTING.md)": "development/)",
     "<LICENSE>": "[LICENSE](https://github.com/TIDES-transit/TIDES/blob/main/LICENSE)",
     "contributors.md)": "development/#contributors)",
     "architecture.md)": "architecture)",
     "tables.md": "tables",
+    "https://tides-transit.github.io/TIDES/governance/":"governance.md"
 }
 
 
@@ -108,6 +110,63 @@ def define_env(env):
         for s in samples:
             md_table += datapackage_to_row(os.path.join(sample_dir, s, "TIDES"), fields)
         return md_table
+
+
+    @env.macro
+    def include_file_sections(
+        filename: str,
+        include_sections: list[str] = [],
+        exclude_sections: list[str] = [],
+        downshift_h1=True,
+        start_line: int = 0,
+        end_line: int = None,
+        code_type: str = None,
+    ):
+        """Wrapper around include_file to only include some sections.
+
+        Args:
+            filename (str): _description_
+            sections: list of sections to include in order If not found will skip.
+            downshift_h1 (bool, optional): _description_. Defaults to True.
+            start_line (int, optional): _description_. Defaults to 0.
+            end_line (int, optional): _description_. Defaults to None.
+            code_type (str, optional): _description_. Defaults to None.
+        """
+
+        full_file_md = include_file(filename,downshift_h1,start_line,end_line,code_type)
+
+        # Normalize titles for comparison
+        include_titles = set(title.lower().strip() for title in include_sections)
+        exclude_titles = set(title.lower().strip() for title in exclude_sections)
+
+        # Check for conflicts between include and exclude lists
+        if not include_titles.isdisjoint(exclude_titles):
+            conflicting_titles = include_titles.intersection(exclude_titles)
+            raise ValueError(f"Conflicting section titles to include and exclude: {conflicting_titles}")
+
+        # Regex to find a markdown heading (e.g., # Heading, ## Sub-heading, etc.)
+        heading_regex = re.compile(r'^(#{1,6})\s+(.*)', re.MULTILINE)
+
+        # Split the markdown content by headings to process sections
+        parts = re.split(heading_regex, full_file_md)
+        parts=parts[1:]
+
+        # Process in triples: (level, title, content)
+        sections = []
+        for i in range(0, len(parts), 3):
+            level, title, content = parts[i:i+3]
+            sections.append((level, title.strip(), content.strip()))
+        
+        # Extract the desired sections
+        extracted_content = []
+        for level, title, content in sections:
+            title_lower = title.lower()
+            if (title_lower in include_titles or not include_titles) and title_lower not in exclude_titles:
+                heading = f"{level} {title}"
+                extracted_content.append(heading)
+                extracted_content.append(content)
+
+        return "\n\n".join(extracted_content)
 
     @env.macro
     def include_file(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,4 +84,4 @@ nav:
   - Data Package: datapackage.md
   - Sample Data: samples.md
   - Development: development.md
-  - Governance: governance/index.md
+  - Governance: governance.md


### PR DESCRIPTION
Fixes issue #175

Also:

-  Splits out CLA
-  Adds all contributors listed in GitHub team to contributors.md
-  Reduces redundant sections between contributing.md and /development using a macro `include_file_sections`
-  Moves governance.md from docs/governance to docs/ so the link isn't governance/governance/index.html (ugly!)

