### PR TITLE
Add CODEOWNERS consistent with TIDES governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+
+# Default owner of repository is all tides contributors
+* @tides-transit/contributors
+
+# The TIDES Board must approval all normative changes to the TIDES specification
+/spec/ @tides-transit/tides-board
+
+# The TIDES Board must approve all changes to governance and its associated documents
+/docs/governance.md @tides-transit/tides-board
+/docs/governance/ @tides-transit/tides-board
+/LICENSES @tides-transit/tides-board
+/CODE_OF_CONDUCT.md @tides-transit/tides-board
+/CLA.md @tides-transit/tides-board


### PR DESCRIPTION
Adds TIDES Contributors as default CODEOWNERS and TIDES Board for `/spec` directory and all governance docs. 

Refs: 

- [The format and purpose of of the CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
- [TIDES Governance](https://tides-transit.github.io/TIDES/main/governance/)

Fixes #182 once branch protection rules added.
