### PR TITLE
add remove stale branches gh-action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,11 +20,14 @@ jobs:
         fetch-depth: 0
     - name: Set github reference as Slug environment variable
       run: |
+        echo "github.head_ref: "${{ github.head_ref }};
         echo "Slug=$(echo "${{ github.head_ref }}" | sed "s/\//\-/g")" >> "$GITHUB_ENV"
+        echo "Slug: "${{ env.Slug }};
     - name: If no github.head_ref, use last chunk of github.ref as Slug
       if: github.head_ref == ''
       run: |
         IFS="\/";
+        echo "github.ref: "${{ github.ref }};
         read -a strarr <<< "${{ github.ref }}";
         last_ref="${strarr[${#strarr[*]}-1]}";
         echo "Slug=$(echo $last_ref)" >> "$GITHUB_ENV"

--- a/.github/workflows/remove-stale.yml
+++ b/.github/workflows/remove-stale.yml
@@ -1,0 +1,14 @@
+on:
+    schedule:
+      - cron: "0 0 * * *" # Everday at midnight
+  
+jobs:
+    remove-stale-branches:
+        name: Remove Stale Branches
+        runs-on: ubuntu-latest
+        steps:
+        - uses: fpicalausa/remove-stale-branches@v1
+          with:
+            dry-run: true # Check out the console output before setting this to false
+            days-before-branch-stale: 30
+            days-before-branch-delete: 7


### PR DESCRIPTION
Will mark branches as stale after 30 days of inaction and remove them 7 days later unless action is taken.

- Currently implemented as a dry-run so no deletions will be made until we are happy with the config.
- Must be implemented in `main` branch to work.

Fixes #200