### PR TITLE
Fix up event ref for deletion of docs associated with deleted branch

### DIFF
--- a/.github/workflows/clean-docs.yml
+++ b/.github/workflows/clean-docs.yml
@@ -17,7 +17,7 @@ jobs:
       if: github.head_ref == ''
       run: |
         IFS="\/";
-        read -a strarr <<< "${{ github.ref }}";
+        read -a strarr <<< "${{ github.event.ref }}";
         last_ref="${strarr[${#strarr[*]}-1]}";
         echo "Slug=$(echo $last_ref)" >> "$GITHUB_ENV"
     - name: Document which reference


### PR DESCRIPTION
# Pull Request

Changes the branch lineage referenced in `clean-docs.yml` so that older docs versions associated with a branch's deletion event are targeted correctly for deletion, rather than the docs associated with the head branch after that event has happened. This is a follow-up to #215.

The event trigger behavior and the resulting branch ref was tested on a private repo before creating this PR.