### PR TITLE
Update TIDES Program Manager, Form URL in Governance Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for contributing to the TIDES Project. This document outlines the process for contributing to the project and documents the governance roles and approach for decision-making. Where [TIDES Governance][TIDES-governance] and this document differ, the [TIDES Governance][TIDES-governance] shall take precedence.
 
-[contributor registration form]: https://forms.office.com/Pages/ResponsePage.aspx?id=i_a_3SpIc0WB4P74FWpP0Hpd6kyRp1VEg8rnx5-CwORUMFFGTzBYRktEMkJRWVg4Qlg3SkM0VEJKVi4u
+[contributor registration form]: https://docs.google.com/forms/d/e/1FAIpQLSfQUjKHfV64uDBAYAt0OSPgYCe_BGgcAPWXi-m0PSlX6edCIQ/viewform?usp=header
 [code of conduct]:./docs/governance/policies/code_of_conduct.md
 [CLA]:./docs/governance/policies/CLA.md
 [change-policy]:./docs/governance/policies/change-management.md

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -7,7 +7,7 @@ Governance of the TIDES Project is achieved through the definition and filling o
 | [TIDES Board](#tides-board-of-directors) | <ul><li>[Michael Eichler](https://github.com/planitmichael), [Washington Metropolitan Area Transit Authority](https://hwww.wmata.com/)</li><li>[Evan Siroky](https://github.com/evansiroky), [Caltrans](https://dot.ca.gov)</li><li>[John Levin](https://github.com/jlstpaul), [Metro Transit (Minneapolis)](https://www.metrotransit.org/)</li><li>[Elizabeth Sall](https://github.com/e-lo), [UrbanLabs LLC](https://urbanlabs.io)</li><li>[Gabriel Sánchez Martinez](https://github.com/gabriel-korbato), [Korbato](https://korbato.com/)</li></ul> |
 | [TIDES Board Coordinator](#board-coordinator) | [John Levin](https://github.com/jlstpaul), [Metro Transit (Minneapolis)](https://www.metrotransit.org/) |
 | [TIDES Manager](#tides-manager) | [MobilityData](https://mobilitydata.org) |
-| [TIDES Program Managers](#tides-program-manager) | <ul><li>[Cristhian Hellion](https://ca.linkedin.com/in/cristhian-hellion-2a698124), [MobilityData](https://mobilitydata.org)</li><li>[Chris Alfano](https://github.com/themightychris), [Jarvus Innovations](https://jarv.us/) |
+| [TIDES Program Managers](#tides-program-manager) | <ul><li>[Cristhian Hellion](https://ca.linkedin.com/in/cristhian-hellion-2a698124), [MobilityData](https://mobilitydata.org)</li><li>[Chris Alfano](https://github.com/themightychris), [Jarvus Innovations](https://jarv.us/)</li></ul> |
 | [TIDES Contributor](#tides-contributor) | [List of Contributors](development.md#contributors.md) |
 | [TIDES Stakeholder](#tides-stakeholder) | Anyone who has an interest in or could be directly affected by the TIDES specification and tools. |
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -7,7 +7,7 @@ Governance of the TIDES Project is achieved through the definition and filling o
 | [TIDES Board](#tides-board-of-directors) | <ul><li>[Michael Eichler](https://github.com/planitmichael), [Washington Metropolitan Area Transit Authority](https://hwww.wmata.com/)</li><li>[Evan Siroky](https://github.com/evansiroky), [Caltrans](https://dot.ca.gov)</li><li>[John Levin](https://github.com/jlstpaul), [Metro Transit (Minneapolis)](https://www.metrotransit.org/)</li><li>[Elizabeth Sall](https://github.com/e-lo), [UrbanLabs LLC](https://urbanlabs.io)</li><li>[Gabriel Sánchez Martinez](https://github.com/gabriel-korbato), [Korbato](https://korbato.com/)</li></ul> |
 | [TIDES Board Coordinator](#board-coordinator) | [John Levin](https://github.com/jlstpaul), [Metro Transit (Minneapolis)](https://www.metrotransit.org/) |
 | [TIDES Manager](#tides-manager) | [MobilityData](https://mobilitydata.org) |
-| [TIDES Program Manager](#tides-program-manager) | TBD |
+| [TIDES Program Manager](#tides-program-manager) | [Cristhian Hellion](https://ca.linkedin.com/in/cristhian-hellion-2a698124), MobilityData |
 | [TIDES Contributor](#tides-contributor) | [List of Contributors](development.md#contributors.md) |
 | [TIDES Stakeholder](#tides-stakeholder) | Anyone who has an interest in or could be directly affected by the TIDES specification and tools. |
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -7,7 +7,7 @@ Governance of the TIDES Project is achieved through the definition and filling o
 | [TIDES Board](#tides-board-of-directors) | <ul><li>[Michael Eichler](https://github.com/planitmichael), [Washington Metropolitan Area Transit Authority](https://hwww.wmata.com/)</li><li>[Evan Siroky](https://github.com/evansiroky), [Caltrans](https://dot.ca.gov)</li><li>[John Levin](https://github.com/jlstpaul), [Metro Transit (Minneapolis)](https://www.metrotransit.org/)</li><li>[Elizabeth Sall](https://github.com/e-lo), [UrbanLabs LLC](https://urbanlabs.io)</li><li>[Gabriel Sánchez Martinez](https://github.com/gabriel-korbato), [Korbato](https://korbato.com/)</li></ul> |
 | [TIDES Board Coordinator](#board-coordinator) | [John Levin](https://github.com/jlstpaul), [Metro Transit (Minneapolis)](https://www.metrotransit.org/) |
 | [TIDES Manager](#tides-manager) | [MobilityData](https://mobilitydata.org) |
-| [TIDES Program Manager](#tides-program-manager) | [Cristhian Hellion](https://ca.linkedin.com/in/cristhian-hellion-2a698124), MobilityData |
+| [TIDES Program Managers](#tides-program-manager) | <ul><li>[Cristhian Hellion](https://ca.linkedin.com/in/cristhian-hellion-2a698124), [MobilityData](https://mobilitydata.org)</li><li>[Chris Alfano](https://github.com/themightychris), [Jarvus Innovations](https://jarv.us/) |
 | [TIDES Contributor](#tides-contributor) | [List of Contributors](development.md#contributors.md) |
 | [TIDES Stakeholder](#tides-stakeholder) | Anyone who has an interest in or could be directly affected by the TIDES specification and tools. |
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -4,7 +4,7 @@ Governance of the TIDES Project is achieved through the definition and filling o
 
 | **Role** | **Who** |
 | -------- | ----- |
-| [TIDES Board](#tides-board-of-directors) | <ul><li>[Michael Eichler](https://github.com/planitmichael), [Washington Metropolitan Area Transit Authority](https://hwww.wmata.com/)</li><li>[Evan Siroky](https://github.com/evansiroky), [Caltrans](https://dot.ca.gov)</li><li>[John Levin](https://github.com/jlstpaul), [Metro Transit (Minneapolis)](https://www.metrotransit.org/)</li><li>[Elizabeth Sall](https://github.com/e-lo), [UrbanLabs LLC](https://urbanlabs.io)</li><li>[Gabriel Sánchez Martinez](https://github.com/gabriel-korbato), [Korbato](https://korbato.com/)</li></ul> |
+| [TIDES Board](#tides-board-of-directors) | <ul><li>[Michael Eichler](https://github.com/planitmichael), [Washington Metropolitan Area Transit Authority](https://hwww.wmata.com/)</li><li>[Evan Siroky](https://github.com/evansiroky), [Caltrans](https://dot.ca.gov)</li><li>[John Levin](https://github.com/jlstpaul)</li><li>[Elizabeth Sall](https://github.com/e-lo), [UrbanLabs LLC](https://urbanlabs.io)</li><li>[Gabriel Sánchez Martinez](https://github.com/gabriel-korbato), [Korbato](https://korbato.com/)</li></ul> |
 | [TIDES Board Coordinator](#board-coordinator) | [John Levin](https://github.com/jlstpaul) |
 | [TIDES Manager](#tides-manager) | [MobilityData](https://mobilitydata.org) |
 | [TIDES Program Managers](#tides-program-manager) | <ul><li>[Cristhian Hellion](https://ca.linkedin.com/in/cristhian-hellion-2a698124), [MobilityData](https://mobilitydata.org)</li><li>[Chris Alfano](https://github.com/themightychris), [Jarvus Innovations](https://jarv.us/)</li></ul> |

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -120,4 +120,4 @@ TIDES is governed by a Board of Directors. The Board meets roughly one a month a
 - Initial release of the TIDES Governance document.
 - Establishment of governance principles, roles, policies, and procedures.
 
-[contributor-registration]: https://forms.office.com/Pages/ResponsePage.aspx?id=i_a_3SpIc0WB4P74FWpP0Hpd6kyRp1VEg8rnx5-CwORUMFFGTzBYRktEMkJRWVg4Qlg3SkM0VEJKVi4u
+[contributor-registration]: https://docs.google.com/forms/d/e/1FAIpQLSfQUjKHfV64uDBAYAt0OSPgYCe_BGgcAPWXi-m0PSlX6edCIQ/viewform?usp=header

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -5,7 +5,7 @@ Governance of the TIDES Project is achieved through the definition and filling o
 | **Role** | **Who** |
 | -------- | ----- |
 | [TIDES Board](#tides-board-of-directors) | <ul><li>[Michael Eichler](https://github.com/planitmichael), [Washington Metropolitan Area Transit Authority](https://hwww.wmata.com/)</li><li>[Evan Siroky](https://github.com/evansiroky), [Caltrans](https://dot.ca.gov)</li><li>[John Levin](https://github.com/jlstpaul), [Metro Transit (Minneapolis)](https://www.metrotransit.org/)</li><li>[Elizabeth Sall](https://github.com/e-lo), [UrbanLabs LLC](https://urbanlabs.io)</li><li>[Gabriel Sánchez Martinez](https://github.com/gabriel-korbato), [Korbato](https://korbato.com/)</li></ul> |
-| [TIDES Board Coordinator](#board-coordinator) | [John Levin](https://github.com/jlstpaul), [Metro Transit (Minneapolis)](https://www.metrotransit.org/) |
+| [TIDES Board Coordinator](#board-coordinator) | [John Levin](https://github.com/jlstpaul) |
 | [TIDES Manager](#tides-manager) | [MobilityData](https://mobilitydata.org) |
 | [TIDES Program Managers](#tides-program-manager) | <ul><li>[Cristhian Hellion](https://ca.linkedin.com/in/cristhian-hellion-2a698124), [MobilityData](https://mobilitydata.org)</li><li>[Chris Alfano](https://github.com/themightychris), [Jarvus Innovations](https://jarv.us/)</li></ul> |
 | [TIDES Contributor](#tides-contributor) | [List of Contributors](development.md#contributors.md) |


### PR DESCRIPTION
# Minor updates to Governance Docs

This pull request is meant to:
1. Ensure that Cristhian Hellion (MobilityData) and Chris Alfano (Jarvus Innovations) are listed as the TIDES Program Managers within the governance documentation for TIDES, to reflect the management of, and accountability for, project activities in calendar year 2025.
2. Trigger a new workflow run of `pages-build-deployment` to determine if the issue that caused [this failure](https://github.com/TIDES-transit/TIDES/actions/runs/13705133728) is still present.
   - _UPDATE: the workflow [ran successfully](https://github.com/TIDES-transit/TIDES/actions/runs/15597650737/job/43931516677?pr=232) as of 7:12pm ET, 11 June 2025._
3. Replace the URL for individuals to "request to be a Contributor by completing an online form" with link to [the new form](https://docs.google.com/forms/d/e/1FAIpQLSfQUjKHfV64uDBAYAt0OSPgYCe_BGgcAPWXi-m0PSlX6edCIQ/viewform?usp=header).

By contributing to this project, all contributors certify to the Developer Certificate of Origin in [CONTRIBUTING.md](CONTRIBUTING.md#contributor-agreement).
