### PR TITLE
Formalizing Release v1.0 -- Stable Baseline

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -19,3 +19,7 @@ MD033: false
 
 # Remove "no emphasis as heading"
 MD036: false
+
+# Allow duplicate headings under different parents (needed for CHANGELOG.md)
+MD024:
+  siblings_only: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to the TIDES specification will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0] - 2025-12-23
+
+### Changed
+
+- Promoted to stable release (no normative changes from v1.0-beta.1)
+
+### Added
+
+- CHANGELOG.md to track specification changes
+
+## [1.0-beta.1] - 2024-01-06
+
+### Added
+
+- Initial pre-release of the TIDES data specification
+- **Core Tables:**
+    - `vehicle_locations` - Timestamped vehicle locations and speeds.
+    - `passenger_events` - Timestamped passenger-related events, including boardings and alightings.
+    - `fare_transactions` - Timestamped fare transaction, associated with devices.
+    - `stop_visits` - Summarized boarding, alighting, arrival, departure, and other events (kneel engaged, ramp deployed, etc.) by trip and stop for each service date.
+    - `trips_performed` - Trips performed for each service date.
+    - `station_activities` - Summarized transactions, entries, and exits by stop or station and time period for each service date (for events not associated with a trip).
+    - `devices` - Measurement devices, such as AVL, APC, and AFC devices, associated with vehicles or stops or stations.
+    - `train_cars` - Assets that comprise vehicles, such as train cars, with descriptive information.
+    - `vehicle_train_cars` - Relationships between assets and vehicles.
+    - `vehicles` - Vehicles, including buses and train consists, with descriptive information.
+    - `operators` - Personnel who operate vehicles.
+- TIDES Data Package Profile for data packaging
+- Sample template data package structure
+- Validation tools and test scripts
+- Documentation site with governance policies
+- Change management policy with semantic versioning
+
+[Unreleased]: https://github.com/TIDES-transit/TIDES/compare/v1.0...HEAD
+[1.0]: https://github.com/TIDES-transit/TIDES/compare/v1.0-beta.1...v1.0
+[1.0-beta.1]: https://github.com/TIDES-transit/TIDES/releases/tag/v1.0-beta.1


### PR DESCRIPTION
## Summary

Promotes TIDES specification to `v1.0` stable release. No normative changes from `v1.0-beta.1`. This release establishes a stable baseline before introducing `v2.0` breaking changes.

## Changes

- **CHANGELOG.md** added that:
  - follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
  - documents `v1.0-beta.1` pre-release (2024-01-06)
  - establishes `v1.0` stable (2025-12-23)
  - provides `[Unreleased]` section for tracking `v2.0` changes
- **.markdownlint.yaml** now allows duplicate headings under different parents (required for standard CHANGELOG format)

## Why now?

As we close out an active year of TIDES implementations and community input, our current Issues Working Group has determined the details of several normative change proposals for `v2.0`, including breaking changes (from issues #235, #237) and new features (#220, #240).

_- For reference, the Working Group's notes from the Fall 2025 meetings on [December 1](https://docs.google.com/document/d/1vjd7788aC0Ua4tySMl7ytcDjSV_lUMXi4FPV_-c3ArM/edit?usp=sharing) and [December 10](https://docs.google.com/document/d/1cIYkhlEscs1wpUZz8D2USQr8EYJNQg5NDeUJQHtN2gw/edit?usp=sharing)._

Before merging those changes, we need a stable v1.0 reference point for implementations currently using `v1.0-beta.1`, migration documentation for v2.0 breaking changes, as well as clear versioning per the [change management policy](https://tides-transit.org/main/governance/change-management/).

## Release checklist

Per change management policy:

- [x] Reviewed/approved by 2+ Board members
- [x] Tag as `v1.0` after merge
- [x] Create GitHub Release
- [ ] Notice to community