### PR TITLE
Clarify event_count usage and APC data guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `passenger_events.event_count` description clarified to specify when values > 1 are appropriate, direct aggregated APC data to stop_visits, and clarify that 0 is distinct from null ([#236](https://github.com/TIDES-transit/TIDES/issues/236))
+
 ## [1.0] - 2025-12-23
 
 ### Changed

--- a/spec/passenger_events.schema.json
+++ b/spec/passenger_events.schema.json
@@ -132,7 +132,7 @@
       "name": "event_count",
       "type": "integer",
       "title": "Event count",
-      "description": "Count for this event, e.g., 3 for a Passenger Boarding event with 3 boardings, default is  `1`",
+      "description": "Count for this event. Default is `1`. Use values > 1 only for truly simultaneous events (e.g., a parent carrying a child through a doorway as a single boarding event). Aggregated APC counts (e.g., '6 passengers boarded at this stop') should be recorded in stop_visits, not passenger_events, since passenger_events is intended for discrete, instantaneous events. A value of `0` indicates that the event was recorded but no passengers were counted (e.g., door opened but no one boarded), which is distinct from null/missing data.",
       "constraints": {
         "minimum": 0
       }


### PR DESCRIPTION
## Summary

This change clarifies the `passenger_events.event_count` field documentation to provide guidance on proper usage, distinguishing between individual passenger events and aggregated APC counts.

Resolves #236

## Changes

- `spec/passenger_events.schema.json` updated `event_count` description to:
  - specify that values > 1 should only be used for truly simultaneous events (e.g., parent carrying child through doorway)
  - direct aggregated APC counts to stop_visits table instead, and
  - clarify that a value of `0` indicates a recorded event with no passengers, distinct from null/missing data
- `CHANGELOG.md` added entry under `[Unreleased]`

## Reason for change

The original description was ambiguous about when to use `event_count > 1` vs. recording aggregated data. Some TIDES implementers have noted the lack of clarity for whether to put APC summary data (for instance, "6 passengers boarded at this stop") into `passenger_events` or `stop_visits`.

This clarification establishes that `passenger_events` is for discrete, instantaneous events, while `stop_visits` is the appropriate destination for aggregated counts.

_- For reference, see related discussion in [Issue #236](https://github.com/TIDES-transit/TIDES/issues/236) and Fall 2025 TIDES Issues Working Group notes from [December 1](https://docs.google.com/document/d/1vjd7788aC0Ua4tySMl7ytcDjSV_lUMXi4FPV_-c3ArM/edit?usp=sharing)_

## Review checklist

Per [TIDES change management policy](https://tides-transit.org/main/governance/policies/change-management/#normative-content), the following must be met before feature branch changes can merge to `develop` branch:

- [x] All JSON files validate
- [ ] Reviewed and approved by 2+ contributors or board members
