### PR TITLE
Add new vehicle_label field to vehicles table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `vehicles.vehicle_label` optional field for user-visible vehicle numbers displayed on exterior, distinguishing from internal `vehicle_id`. Aligns with GTFS-realtime VehicleDescriptor.label ([#240](https://github.com/TIDES-transit/TIDES/issues/240))
+
 ## [1.0] - 2025-12-23
 
 ### Changed

--- a/samples/template/TIDES/vehicles.csv
+++ b/samples/template/TIDES/vehicles.csv
@@ -1,1 +1,1 @@
-vehicle_id,vehicle_start,vehicle_end,model_name,facility_name,capacity_seated,capacity_wheelchair,capacity_bike,bike_rack,capacity_standing
+vehicle_id,vehicle_label,vehicle_start,vehicle_end,model_name,facility_name,capacity_seated,capacity_wheelchair,capacity_bike,bike_rack,capacity_standing

--- a/spec/vehicles.schema.json
+++ b/spec/vehicles.schema.json
@@ -16,6 +16,11 @@
       }
     },
     {
+      "name": "vehicle_label",
+      "type": "string",
+      "description": "User-visible label for the vehicle, such as the vehicle number displayed on the exterior. This may differ from vehicle_id, which is the internal identifier. Aligns with GTFS-realtime VehicleDescriptor.label."
+    },
+    {
       "name": "vehicle_start",
       "type": "datetime",
       "description": "The timestamp at which the vehicle or train consist is first in operation (i.e., when the consist has been created). Required if Train_car is used."


### PR DESCRIPTION
## Summary

Adds an optional `vehicle_label` field to the `vehicles` table to distinguish between internal vehicle IDs and public-facing vehicle numbers displayed on the exterior if vehicles. This new field aligns with [GTFS-realtime VehicleDescriptor](https://gtfs.org/documentation/realtime/reference/#message-vehicledescriptor) which has both `id` and `label`.

Resolves #240

## Changes

- `spec/vehicles.schema.json` added new optional field `vehicle_label`:
  - type: `string`
  - description: `User-visible label for the vehicle, such as the vehicle number displayed on the exterior. This may differ from vehicle_id, which is the internal identifier. Aligns with GTFS-realtime VehicleDescriptor.label.`
  - no constraints (optional field)
  - positioned logically after `vehicle_id`
- `CHANGELOG.md` added entry under `[Unreleased]` > `### Added`

## Reason for this change

Agencies often have two different identifiers for vehicles:
- an internal ID (`vehicle_id`) used in fleet management, maintenance systems, and internal databases
- a public-facing number (`vehicle_label`) displayed on the vehicle exterior for passengers and customer service

Currently the TIDES spec only has `vehicle_id`, which forces agencies to either lose the public-facing number or use inconsistent workarounds. Adding `vehicle_label` provides a standard place for this common data element (and aligns with GTFS-realtime's `VehicleDescriptor.label`).

_- See related discussion in [Issue #240](https://github.com/TIDES-transit/TIDES/issues/240) and Fall 2025 TIDES Issues Working Group notes from [December 10](https://docs.google.com/document/d/1cIYkhlEscs1wpUZz8D2USQr8EYJNQg5NDeUJQHtN2gw/edit?usp=sharing)._

## Review checklist

Per [change management policy](https://tides-transit.org/main/governance/policies/change-management/#normative-content), the following must be met before feature branch changes can merge to `develop` branch:

- [x] All JSON files validate
- [ ] Reviewed and approved by 2+ contributors or board members

---

### Community review status (updated September 2, 2026)

**How community review works:** Per the [TIDES Change Management Policy](https://tides-transit.org/main/governance/policies/change-management/#__tabbed_1_4), a proposal moves forward once at least three TIDES Contributors outside the originating working group publicly comment with a score: **Accepted**, **Accepted with minor changes**, or **Substantially revised**. A few sentences with your read of the proposal is a complete review.

**Originating working group (Fall 2025 Issues Working Group, December 1 and 10, 2025 sessions):** Christopher Yamas, Gabriel Sánchez Martínez, Ian Thistle, Jay Gordon, John Levin, Joey Reid, Spenser Sutinen. Their work is reflected in the proposal itself; community review comes from Contributors beyond this group.

**Review so far:** @lauriemerrell has approved this PR (Accepted), and @paulswartz shared the MBTA ground truth on label uniqueness that settled the design; a scored comment here would add that review to the record.

**Thanks to everyone who has weighed in on this proposal; it is moving into final consideration for v2.0. Further comments are always welcome.**

The full v2.0 map lives on #271.
