### PR TITLE
Add device_status table for tracking device availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `device_status` table for tracking device operational status changes over time ([#242](https://github.com/TIDES-transit/TIDES/issues/242))
+    - Tracks when devices go offline, return to service, or experience errors
+    - Two timestamps: `record_timestamp` (when recorded) vs `status_change_timestamp` (when status actually changed)
+    - Supports data quality analysis by distinguishing missing data due to device outages from actual service patterns
+
 ## [1.0] - 2025-12-23
 
 ### Changed

--- a/samples/template/TIDES/datapackage.json
+++ b/samples/template/TIDES/datapackage.json
@@ -25,6 +25,20 @@
     ],
     "resources": [
         {
+            "name": "device_status",
+            "profile": "tabular-data-resource",
+            "path": "device_status.csv",
+            "schema": "https://raw.githubusercontent.com/TIDES-transit/TIDES/main/spec/device_status.schema.json",
+            "sources": [
+                {
+                    "title": "Where did data come from?",
+                    "component": "Type of technology component, e.g. `Device monitoring system`",
+                    "product": "Product used.",
+                    "vendor": "Vendor selling product."
+                }
+            ]
+        },
+        {
             "name": "devices",
             "profile": "tabular-data-resource",
             "path": "devices.csv",

--- a/samples/template/TIDES/device_status.csv
+++ b/samples/template/TIDES/device_status.csv
@@ -1,0 +1,1 @@
+device_status_id,service_date,record_timestamp,status_change_timestamp,device_id,status_type,status_reason

--- a/spec/device_status.schema.json
+++ b/spec/device_status.schema.json
@@ -1,0 +1,80 @@
+{
+  "primaryKey": "device_status_id",
+  "missingValues": [
+    "NA",
+    "NaN",
+    ""
+  ],
+  "fields": [
+    {
+      "name": "device_status_id",
+      "type": "string",
+      "title": "Device status ID",
+      "description": "Unique identifier for this device status record.",
+      "constraints": {
+        "required": true,
+        "unique": true
+      }
+    },
+    {
+      "name": "service_date",
+      "type": "date",
+      "title": "Service date",
+      "description": "Service date associated with this status record. Optional because device status may not align with transit service dates."
+    },
+    {
+      "name": "record_timestamp",
+      "type": "datetime",
+      "title": "Record timestamp",
+      "description": "Timestamp when this status record was created in the system. May differ from status_change_timestamp if status changes are recorded retroactively.",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "status_change_timestamp",
+      "type": "datetime",
+      "title": "Status change timestamp",
+      "description": "Timestamp when the device status actually changed. This is the time the device went offline, came back online, or experienced the status change.",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "device_id",
+      "type": "string",
+      "title": "ID referencing devices.device_id",
+      "description": "Identifies the device. References the devices table.",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "status_type",
+      "type": "string",
+      "title": "Status type",
+      "description": "Type of device status. Examples: online, offline, maintenance, error, degraded. Agencies may define additional status types as needed.",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "status_reason",
+      "type": "string",
+      "title": "Status reason",
+      "description": "Optional reason or description for the status change. Examples: scheduled maintenance, power failure, communication error, sensor malfunction."
+    }
+  ],
+  "foreignReferences": [
+    {
+      "fields": "device_id",
+      "reference": {
+        "resource": "devices",
+        "fields": "device_id"
+      }
+    }
+  ],
+  "name": "device_status.schema.json",
+  "description": "Records device operational status changes over time. This table tracks when devices (APCs, fare gates, AVL units, etc.) go offline, return to service, or experience errors. Enables data quality analysis by distinguishing between missing data due to device outages versus actual service patterns.",
+  "_table_type": "Event"
+}

--- a/spec/tides-datapackage-profile.json
+++ b/spec/tides-datapackage-profile.json
@@ -293,6 +293,7 @@
           },
           "tides-table": {
             "enum": [
+              "device_status",
               "devices",
               "fare_transactions",
               "operators",


### PR DESCRIPTION
## Summary

This PR adds a new `device_status` table for tracking device operational status changes over time. The reason for this change is to enable agencies to understand data gaps due to device outages versus actual service patterns.

This is a **non-breaking change** (new optional table).

Resolves #242

## Schema Design

**Fields:**
- `device_status_id` (required, unique) - primary key
- `service_date` (optional) - service date for the status record
- `record_timestamp` (required) - when the status record was created in the system
- `status_change_timestamp` (required) - when the device status actually changed
- `device_id` (required) - foreign key to devices table
- `status_type` (required) - type of status (online, offline, maintenance, error, degraded, etc.)
- `status_reason` (optional) - reason for the status change

**Design Decisions (per Dec 2025 working group):**
- two timestamps: `record_timestamp` vs `status_change_timestamp` - this allows for retroactive recording
- `service_date` is optional, as device status may not align with transit service dates
- this table **excludes** resolution time fields, as that type of data is uncharacteristic to the TIDES scope (seems more like administrative, work-order-like, and would require updating records)

## Files Changed

**New:**
- `spec/device_status.schema.json` - new table schema
- `samples/template/TIDES/device_status.csv` - template csv file

**Modified:**
- `spec/tides-datapackage-profile.json` - added to tides-table enum
- `samples/template/TIDES/datapackage.json` - added resource entry
- `CHANGELOG.md` - documented new table

_- See related discussion in #242 and Fall 2025 TIDES Issues Working Group follow-up meeting notes from [December 10](https://docs.google.com/document/d/1cIYkhlEscs1wpUZz8D2USQr8EYJNQg5NDeUJQHtN2gw/edit?usp=sharing)._

## Usage Notes

Each record represents a single status change event. To determine device availability over a time period, consumers query status changes and apply logic based on the most recent `status_change_timestamp`.

## Review checklist

Per [change management policy](https://tides-transit.org/main/governance/policies/change-management/#normative-content), the following must be met before feature branch changes can merge to `develop` branch:

- [x] All JSON files validate
- [ ] Reviewed and approved by 2+ contributors or board members
