### PR TITLE
Update TIDES governance page: current Program Manager affiliations

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -7,7 +7,7 @@ Governance of the TIDES Project is achieved through the definition and filling o
 | [TIDES Board](#tides-board-of-directors) | <ul><li>[Michael Eichler](https://github.com/planitmichael), [Washington Metropolitan Area Transit Authority](https://hwww.wmata.com/)</li><li>[Evan Siroky](https://github.com/evansiroky), [Caltrans](https://dot.ca.gov)</li><li>[John Levin](https://github.com/jlstpaul)</li><li>[Elizabeth Sall](https://github.com/e-lo), [UrbanLabs LLC](https://urbanlabs.io)</li><li>[Gabriel Sánchez Martinez](https://github.com/gabriel-korbato), [Korbato](https://korbato.com/)</li></ul> |
 | [TIDES Board Coordinator](#board-coordinator) | [John Levin](https://github.com/jlstpaul) |
 | [TIDES Manager](#tides-manager) | [MobilityData](https://mobilitydata.org) |
-| [TIDES Program Managers](#tides-program-manager) | [Christopher Yamas](https://github.com/chrisyamas), MobilityData Contractor |
+| [TIDES Program Manager](#tides-program-manager) | [Christopher Yamas](https://github.com/chrisyamas), MobilityData Contractor |
 | [TIDES Contributor](#tides-contributor) | [List of Contributors](development.md#contributors.md) |
 | [TIDES Stakeholder](#tides-stakeholder) | Anyone who has an interest in or could be directly affected by the TIDES specification and tools. |
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -7,7 +7,7 @@ Governance of the TIDES Project is achieved through the definition and filling o
 | [TIDES Board](#tides-board-of-directors) | <ul><li>[Michael Eichler](https://github.com/planitmichael), [Washington Metropolitan Area Transit Authority](https://hwww.wmata.com/)</li><li>[Evan Siroky](https://github.com/evansiroky), [Caltrans](https://dot.ca.gov)</li><li>[John Levin](https://github.com/jlstpaul)</li><li>[Elizabeth Sall](https://github.com/e-lo), [UrbanLabs LLC](https://urbanlabs.io)</li><li>[Gabriel Sánchez Martinez](https://github.com/gabriel-korbato), [Korbato](https://korbato.com/)</li></ul> |
 | [TIDES Board Coordinator](#board-coordinator) | [John Levin](https://github.com/jlstpaul) |
 | [TIDES Manager](#tides-manager) | [MobilityData](https://mobilitydata.org) |
-| [TIDES Program Managers](#tides-program-manager) | <ul><li>[Cristhian Hellion](https://ca.linkedin.com/in/cristhian-hellion-2a698124), [MobilityData](https://mobilitydata.org)</li><li>[Chris Alfano](https://github.com/themightychris), [Jarvus Innovations](https://jarv.us/)</li></ul> |
+| [TIDES Program Managers](#tides-program-manager) | [Christopher Yamas](https://github.com/chrisyamas), MobilityData Contractor |
 | [TIDES Contributor](#tides-contributor) | [List of Contributors](development.md#contributors.md) |
 | [TIDES Stakeholder](#tides-stakeholder) | Anyone who has an interest in or could be directly affected by the TIDES specification and tools. |
 


### PR DESCRIPTION
Updates the Program Manager row on the governance page to reflect the current assignment per TIDES Board direction. Removes the two prior co-manager entries and lists Christopher Yamas (MobilityData Contractor) as the current TIDES Program Manager.