### PR TITLE
Fix docs build on Python 3.14: add setuptools to docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,4 +10,5 @@ mkdocs-mermaid2-plugin
 mkdocs-redirects
 pandas
 pyyaml
+setuptools
 tabulate


### PR DESCRIPTION
# Pull Request

Fixes the `build-deploy` job in `.github/workflows/docs.yml`, which started failing on all PRs after the workflow's `python-version: '3.x'` started resolving to Python 3.14. Python 3.14 no longer ships `pkg_resources` as part of the default install, and `mike<2.0` (pinned in `docs/requirements.txt`) imports `pkg_resources` on startup, so it crashes with `ModuleNotFoundError: No module named 'pkg_resources'` before doing any work.

Adding `setuptools` to `docs/requirements.txt` restores `pkg_resources` and unblocks the docs build without changing the Python version or upgrading `mike`.

This is not a spec change, so the spec-change checklist does not apply.

By contributing to this project, all contributors certify to the Developer Certificate of Origin in [CONTRIBUTING.md](CONTRIBUTING.md#contributor-agreement).