### PR TITLE
Fix docs build: pin setuptools<81 so pkg_resources remains available

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,5 +10,5 @@ mkdocs-mermaid2-plugin
 mkdocs-redirects
 pandas
 pyyaml
-setuptools
+setuptools<81
 tabulate


### PR DESCRIPTION
# Pull Request

Follow-up to #258. Adding `setuptools` to `docs/requirements.txt` was not enough to unblock the docs build on Python 3.14: pip resolved `setuptools` to version 82.0.1, which no longer bundles the `pkg_resources` module. Since `mike<2.0` (still pinned in this repo) imports `pkg_resources` on startup, the build continues to fail with `ModuleNotFoundError: No module named 'pkg_resources'`.

Pinning `setuptools<81` keeps the install on a setuptools release line that still ships `pkg_resources`, which is the smallest change that unblocks the existing `mike<2.0` pin. A larger follow-up could upgrade `mike` to a 2.x release that no longer depends on `pkg_resources`, but that is out of scope here.

This is not a spec change, so the spec-change checklist does not apply.

By contributing to this project, all contributors certify to the Developer Certificate of Origin in [CONTRIBUTING.md](CONTRIBUTING.md#contributor-agreement).