### PR TITLE
fix(deps): upgrade setuptools to >=83 and resolve dependency chain breakage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Build docs
       run: |
         git fetch origin gh-pages --depth=1
-        mike deploy --push --rebase ${{ env.Slug }}
+        mike deploy --push ${{ env.Slug }}
         echo "Documentation available at: http://tides-transit.github.io/TIDES/${{ env.Slug }}"
   comment:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ Those who want to help with the development of the TIDES specification should re
 
 Please add issues, bugs, and feature requests to [GitHub][github issues].
 
+## Building or Serving the site locally
+
+1. In Terminal, change the directory to where you would like the local clone of this repo to be installed.
+1. Ensure you have an up-to-date version of pip: 
+   - Linux: `pip install pip` or `pip install --upgrade pip`
+   - macOS: `pip3 install pip` or `pip3 install --upgrade pip`
+1. Clone this repository:
+   - `git clone https://github.com/TIDES-transit/TIDES.git`
+1. Change the directory to the cloned repository, and create & enable a Python virtual environment:
+   - `python3 -m venv venv`
+   - `source venv/bin/activate`
+1. Install dependencies:
+   - `pip3 install --force-reinstall -r requirements.txt`
+1. To run the site locally:
+   - `mkdocs serve`
+   - Then go to this address with any browser: `http://127.0.0.1:8000/TIDES/`
+1. To build the site locally only:
+   - `mkdocs build`
+   - the files will end up in the `/site` folder.
+1. Deactivate the Python virtual environment when done:
+   - `deactivate`
+
 ## Acknowledgment
 
 These data schemas and tool definitions developed here are based on the results of research conducted by the Transportation Research Board (TRB) of the National Academies of Science, Engineering, and Medicine (NASEM) under the Transit Cooperative Research Program (TCRP). This research is available at [the National Academies website][tcrp report].

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mike<2.0
+mike>=2.0
 mkdocs
 mkdocs-autorefs
 mkdocs-awesome-pages-plugin
@@ -9,6 +9,6 @@ mkdocs-material
 mkdocs-mermaid2-plugin
 mkdocs-redirects
 pandas
-pyyaml
-setuptools<81
+pyyaml>=6.0.1
+setuptools>=83,<84.0.0
 tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 -r docs/requirements.txt
+frictionless
+jsonschema
+jsonschema-cli
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
 -r docs/requirements.txt
-frictionless
-jsonschema
-jsonschema-cli
-pre-commit


### PR DESCRIPTION
# Description

GitHub security alert flagged `setuptools <83.0.0` in requirements.txt ([CVE-2026-59890](https://www.cve.org/CVERecord?id=CVE-2026-59890), moderate severity). See original email screenshot below.

Upgrading `setuptools` to `>=83` surfaced several downstream breakages, resolved here:

- setuptools >=83 removes `pkg_resources`; pin `mike>=2.0` (was <2.0), since `mike 1.1.2` depended on `pkg_resources`
- pin `pyyaml>=6.0.1` to avoid a build failure against `setuptools 83`
- remove unused `jsonschema-cli` dependency in `/requirements.txt`, which pinned `pyyaml<6.0` and blocked the pyyaml upgrade
- pin `setuptools>=83,<84.0.0` in `/docs/requirements.txt`

Verified with `mkdocs serve`, builds and serves locally after these changes with zero visible issues or bugs.

# README additions

Added instructions on how to serve and build the site locally, tested and functionning.

# Pull Request

Before submitting a pull request, please read [CONTRIBUTING.md](CONTRIBUTING.md).

For spec changes:

- [x] Pull-requests must address an existing issue
- [x] Update relevant documentation.

By contributing to this project, all contributors certify to the Developer Certificate of Origin in [CONTRIBUTING.md](CONTRIBUTING.md#contributor-agreement).

# Original email

<img width="900" height="905" alt="Screenshot 2026-08-10 at 16 18 22" src="https://github.com/user-attachments/assets/abf607ab-0cd1-44ea-a280-c60fef4bcb95" />