### PR TITLE
Document merge execution model for main branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Default owner of repository is all tides contributors
 * @tides-transit/contributors
 
-# The TIDES Board must approval all normative changes to the TIDES specification
+# The TIDES Board must approve all normative changes to the TIDES specification
 /spec/ @tides-transit/tides-board
 
 # The TIDES Board must approve all changes to governance and its associated documents

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,9 +144,13 @@ The TIDES Project Governance and the roles within are detailed in the [TIDES gov
 
 ## Review and Approval Process
 
-The TIDES Board has final approval of all *normative* changes changes to the specificaiton and project governance. All Contributors are permitted and encouraged to discuss and comment on issues and pull requests and make recommendations for changes to the specification.  Contributions made as a pull request by Contributors which do not make any changes to the `/spec` or `/docs/governance` directories may be approved by a another Contributor if it passes the continuous integration tests.
+The TIDES Board has final approval of all *normative* changes to the specification and project governance. All Contributors are permitted and encouraged to discuss and comment on issues and pull requests and make recommendations for changes to the specification.  Contributions made as a pull request by Contributors which do not make any changes to the `/spec` or `/docs/governance` directories may be approved by another Contributor if it passes the continuous integration tests.
 
 Following v1.0, TIDES will adhere to this [change management and versioning policy][change-policy].
+
+### Merge Execution on `main`
+
+Review approvals and merge execution are separate steps. Approving reviews (including Code Owner reviews) satisfy the review requirements on a pull request. Execution of the merge into `main` is then performed by a bypass actor on the branch ruleset: the TIDES Board, the TIDES Manager's repository administrators, or an organization administrator. If your pull request targeting `main` is fully approved and GitHub still shows "Merging is blocked / Cannot update this protected ref," that is the ruleset working as intended, not an error; comment on the pull request to request merge execution. Direct pushes to `main` are not possible for anyone, including administrators; all changes land through approved pull requests.
 
 ## TIDES Code of Conduct
 


### PR DESCRIPTION
# Pull Request

## Summary

Documents the merge execution model for `main`, following the discussion in #275.

The branch ruleset on `main` separates review approval from merge execution: approvals (including Code Owner reviews) satisfy the review requirements, and the merge itself is executed by a bypass actor (TIDES Board, the TIDES Manager's repository administrators, or an organization administrator). This has been the effective behavior since the ruleset was created in November 2023, but it was never documented, which is how the confusion in #275 arose. This PR adds a short "Merge Execution on `main`" subsection to the Review and Approval Process section of CONTRIBUTING.md so the next person who hits "Merging is blocked" on a fully approved PR knows it is working as intended.

Also fixes small typos: "must approval" in CODEOWNERS (flagged in the #275 discussion), and three typos in the Review and Approval Process paragraph.

No normative changes.

## Review checklist

- [ ] Approving review from a Contributor (per CODEOWNERS)
- [ ] Merge executed by a bypass actor per the model documented here
