### PR TITLE
Fix clean-docs workflow for mike 2.x

### DIFF
--- a/.github/workflows/clean-docs.yml
+++ b/.github/workflows/clean-docs.yml
@@ -13,13 +13,10 @@ jobs:
     - name: Set github reference as Slug environment variable
       run: |
         echo "Slug=$(echo "${{ github.head_ref }}" | sed "s/\//\-/g")" >> "$GITHUB_ENV"
-    - name: If no github.head_ref, use last chunk of github.ref as Slug
+    - name: If no github.head_ref, use github.event.ref as Slug
       if: github.head_ref == ''
       run: |
-        IFS="\/";
-        read -a strarr <<< "${{ github.event.ref }}";
-        last_ref="${strarr[${#strarr[*]}-1]}";
-        echo "Slug=$(echo $last_ref)" >> "$GITHUB_ENV"
+        echo "Slug=$(echo "${{ github.event.ref }}" | sed "s/\//\-/g")" >> "$GITHUB_ENV"
     - name: Document which reference
       run: echo "Running for reference ${{ env.Slug }}"
     - name: Set up Python $PYTHON_VERSION
@@ -38,4 +35,4 @@ jobs:
     - name: Delete defunct docs versions
       run: |
         echo "Deleting ${{ env.Slug }} version from docs"
-        mike delete --rebase --push ${{ env.Slug }}
+        mike delete --push ${{ env.Slug }} || echo "No docs version found for ${{ env.Slug }}; nothing to clean"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,13 +21,10 @@ jobs:
     - name: Set github reference as Slug environment variable
       run: |
         echo "Slug=$(echo "${{ github.head_ref }}" | sed "s/\//\-/g")" >> "$GITHUB_ENV"
-    - name: If no github.head_ref, use last chunk of github.ref as Slug
+    - name: If no github.head_ref, use github.ref_name as Slug
       if: github.head_ref == ''
       run: |
-        IFS="\/";
-        read -a strarr <<< "${{ github.ref }}";
-        last_ref="${strarr[${#strarr[*]}-1]}";
-        echo "Slug=$(echo $last_ref)" >> "$GITHUB_ENV"
+        echo "Slug=$(echo "${{ github.ref_name }}" | sed "s/\//\-/g")" >> "$GITHUB_ENV"
     - name: Document which reference
       run: echo "Running for reference ${{ env.Slug }}"
     - name: Set up Python
@@ -52,6 +49,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == false && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
+      - name: Set slug from head ref
+        id: slug
+        run: echo "slug=$(echo "${{ github.head_ref }}" | sed "s/\//\-/g")" >> "$GITHUB_OUTPUT"
+
       - uses: peter-evans/find-comment@v2
         id: fc
         with:
@@ -63,5 +64,5 @@ jobs:
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
-          body: "Documentation available at: [`http://tides-transit.github.io/TIDES/${{ github.head_ref }}`](http://tides-transit.github.io/TIDES/${{ github.head_ref }})"
+          body: "Documentation available at: [`http://tides-transit.github.io/TIDES/${{ steps.slug.outputs.slug }}`](http://tides-transit.github.io/TIDES/${{ steps.slug.outputs.slug }})"
           edit-mode: replace


### PR DESCRIPTION
# Pull Request

## Summary

Follow-up to #275. The `Clean Docs for Deleted References` workflow failed on its first run after the mike upgrade ([run 31626545498](https://github.com/TIDES-transit/TIDES/actions/runs/31626545498)) because it still passed `--rebase`, which mike 2.x removed. Digging in surfaced that the two docs workflows have also been computing slugs inconsistently, which has been quietly duplicating and orphaning docs versions on gh-pages for a while.

Changes:

- **clean-docs.yml:** remove `--rebase` from `mike delete` (matching the #275 fix to docs.yml); tolerate missing versions so branches that never deployed docs don't fail the run.
- **Slug consistency, both workflows:** on non-PR events the workflows took only the last path chunk of the branch name (`fix/setup-tools-vuln/2026-08-10` became `2026-08-10`), while PR builds slugify the full name (`fix-setup-tools-vuln-2026-08-10`). Multi-segment branches therefore deployed under two different slugs, and cleanup deleted only the last-chunk one. All slug computations now use the full name.
- **docs.yml PR comment:** the "Documentation available at" link used the raw branch name with slashes, which 404s for multi-segment branches (as seen on #275). It now uses the slugified name that matches the deployed path.

Housekeeping done alongside (directly on gh-pages, since these were artifacts of the bug): removed 19 orphaned or duplicate docs versions, covering deleted branches, last-chunk duplicates of live branches, and a stray self-version of gh-pages.

No normative changes.
