### PR TITLE
Allow negative departure_load values in stop_visits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed `minimum: 0` constraint from `stop_visits.departure_load`, permitting negative values in unadjusted APC data where probabilistic counts produce them ([#270](https://github.com/TIDES-transit/TIDES/issues/270))
+
 ## [1.0] - 2025-12-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Removed `minimum: 0` constraint from `stop_visits.departure_load`, permitting negative values in unadjusted APC data where probabilistic counts produce them ([#270](https://github.com/TIDES-transit/TIDES/issues/270))
+- Removed `minimum: 0` constraint from `stop_visits.departure_load`. This field is often derived from observations of boardings and alightings that are subject to observation error and those errors may result in negative values ([#270](https://github.com/TIDES-transit/TIDES/issues/270))
 
 ## [1.0] - 2025-12-23
 

--- a/spec/stop_visits.schema.json
+++ b/spec/stop_visits.schema.json
@@ -139,7 +139,7 @@
     {
       "name": "departure_load",
       "type": "integer",
-      "description": "Number of riders on the vehicle when departing the stop. Negative values are permitted and may occur in unadjusted APC data, since passenger counts are probabilistic measurements; data producers should indicate when negative values are present and how they should be interpreted."
+      "description": "Number of riders on the vehicle when departing the stop. `departure_load` is typically derived from boardings and alightings and negative values are possible and permitted due to errors in the APC observations; data producers should document how negative values should be interpreted if present."
     },
     {
       "name": "door_open",

--- a/spec/stop_visits.schema.json
+++ b/spec/stop_visits.schema.json
@@ -139,10 +139,7 @@
     {
       "name": "departure_load",
       "type": "integer",
-      "description": "Number of riders on the vehicle when departing the stop.",
-      "constraints": {
-        "minimum": 0
-      }
+      "description": "Number of riders on the vehicle when departing the stop. Negative values are permitted and may occur in unadjusted APC data, since passenger counts are probabilistic measurements; data producers should indicate when negative values are present and how they should be interpreted."
     },
     {
       "name": "door_open",


### PR DESCRIPTION
## Summary

Removes the `minimum: 0` constraint from `stop_visits.departure_load` to permit negative values. APC boarding and alighting counts are probabilistic measurements, and forcing non-negative loads introduces systematic upward bias in aggregated metrics such as passenger miles (see #270 for the statistical argument and the NTD compliance context from C-TRAN).

It was decided to bring this forward as a PR during the Summer 2026 Issues Working Group meeting, and that decision was further validated and confirmed at the July and August 2026 Contributors Group meetings.

This is a **non-breaking** normative change (constraint relaxation): all previously conformant data remains conformant.

Resolves #270

## Changes

### Schema Changes (stop_visits)

- `departure_load`: removed the `minimum: 0` constraint
- `departure_load`: expanded the field description (non-normative) to note that negative values may occur in unadjusted APC data and that producers should indicate when negative values are present and how to interpret them

### Other Files Updated

- `CHANGELOG.md`

## Notes

- Per the issue discussion, the expectation is that negative values appear in raw or unadjusted data and that producers strive to remove them from processed datasets. Where a producer designates the presence and meaning of negative values (for example `datapackage.json` metadata vs. table-level convention) remains an open documentation question from the issue thread and is out of scope here.
- `bike_load` carries the same constraint and is left unchanged; out of scope for #270.
- The v1.0 to v2.0 migration guide (#274) should gain a consumer note that `departure_load` may be negative.

## Review checklist

Per [change management policy](https://tides-transit.org/main/governance/policies/change-management/#normative-content), the following must be met before feature branch changes can merge to `develop` branch:

- [x] All JSON files validate
- [ ] Reviewed and approved by 2+ contributors or board members

---

### Community review status (updated September 2, 2026)

**How community review works:** Per the [TIDES Change Management Policy](https://tides-transit.org/main/governance/policies/change-management/#__tabbed_1_4), a proposal moves forward once at least three TIDES Contributors outside the originating working group publicly comment with a score: **Accepted**, **Accepted with minor changes**, or **Substantially revised**. A few sentences with your read of the proposal is a complete review.

**Originating working group (July 1, 2026 vehicles session):** Christopher Yamas, John Levin, Laurie Merrell, Gabriel Sánchez Martínez, Joey Reid. Their work is reflected in the proposal itself; community review comes from Contributors beyond this group.

**Review so far:** Community review is complete: @CTRAN-Sutinen (who raised the underlying issue #270) and @jabhij have posted scored reviews, and @mtnsguy weighed in supporting the change.

**Thanks to everyone who has weighed in on this proposal; it is moving into final consideration for v2.0. Further comments are always welcome.**

The full v2.0 map lives on #271.
