### PR TITLE
Update governance and change management policy per 2026-08-27 board approval

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -4,10 +4,11 @@ Governance of the TIDES Project is achieved through the definition and filling o
 
 | **Role** | **Who** |
 | -------- | ----- |
-| [TIDES Board](#tides-board-of-directors) | <ul><li>[Michael Eichler](https://github.com/planitmichael), [Washington Metropolitan Area Transit Authority](https://hwww.wmata.com/)</li><li>[Evan Siroky](https://github.com/evansiroky), [Caltrans](https://dot.ca.gov)</li><li>[John Levin](https://github.com/jlstpaul)</li><li>[Elizabeth Sall](https://github.com/e-lo), [UrbanLabs LLC](https://urbanlabs.io)</li><li>[Gabriel Sánchez Martinez](https://github.com/gabriel-korbato), [Korbato](https://korbato.com/)</li></ul> |
+| [TIDES Board](#tides-board-of-directors) | <ul><li>[Michael Eichler](https://github.com/planitmichael), retired (formerly [Washington Metropolitan Area Transit Authority](https://www.wmata.com/))</li><li>[Evan Siroky](https://github.com/evansiroky), [Caltrans](https://dot.ca.gov)</li><li>[John Levin](https://github.com/jlstpaul)</li><li>[Elizabeth Sall](https://github.com/e-lo), [UrbanLabs LLC](https://urbanlabs.io)</li><li>[Gabriel Sánchez Martinez](https://github.com/gabriel-korbato), [Korbato](https://korbato.com/)</li></ul> |
 | [TIDES Board Coordinator](#board-coordinator) | [John Levin](https://github.com/jlstpaul) |
 | [TIDES Manager](#tides-manager) | [MobilityData](https://mobilitydata.org) |
-| [TIDES Program Manager](#tides-program-manager) | [Christopher Yamas](https://github.com/chrisyamas), MobilityData Contractor |
+| [TIDES Program Manager](#tides-program-manager) | [Carl Fredlund](https://github.com/carlfredl), [MobilityData](https://mobilitydata.org) |
+| [Working Groups](#working-groups) | Chartered by the TIDES Board. Current groups, their charters, chairs, and how to join are listed in the [TIDES Working Groups registry](governance/working-groups.md). |
 | [TIDES Contributor](#tides-contributor) | [List of Contributors](development.md#contributors.md) |
 | [TIDES Stakeholder](#tides-stakeholder) | Anyone who has an interest in or could be directly affected by the TIDES specification and tools. |
 
@@ -34,14 +35,14 @@ TIDES is collectively owned and governed by a Board of Directors.
 
 ### TIDES Board of Directors
 
-TIDES is governed by a Board of Directors. The Board meets roughly one a month and has a [public agenda and minutes](https://docs.google.com/document/d/1C-qynGan-jh4z1bJH_Qv3mJX0lXCHHKkzdrEgJzl3QY/edit?usp=sharing).
+TIDES is governed by a Board of Directors. The Board holds quarterly strategic meetings with the TIDES Manager; the Board Coordinator may convene additional Board meetings as needed. The Board has a [public agenda and minutes](https://docs.google.com/document/d/1C-qynGan-jh4z1bJH_Qv3mJX0lXCHHKkzdrEgJzl3QY/edit?usp=sharing).
 
 #### Board Membership
 
 - Members of the Board decide the number of positions on the Board.
 - Members of the Board select individuals to fill open positions on the Board.
 - Members of the Board may remove any individual from the Board.
-- Members of the Board will each be assigned as an “Owner” of the GitHub Organization for TIDES-transit.
+- The TIDES Board Coordinator is responsible for maintaining control of and managing core TIDES assets, including the GitHub organization, the tides-transit.org domain, cloud data storage resources, and other similar assets.
 
 #### Board Coordinator
 
@@ -63,6 +64,8 @@ TIDES is governed by a Board of Directors. The Board meets roughly one a month a
     - Review and approve each new release of TIDES.
     - Manage Urgent Changes to the standard in collaboration with the TIDES Manager.
     - Resolve issues that arise during the Change Management process that cannot be addressed by the TIDES Manager.
+    - Charter Working Groups and approve their written charters.
+    - Appoint Working Group chairs and approve each chair’s written agreement.
 
 #### Board Member Role and Term
 
@@ -81,6 +84,7 @@ TIDES is governed by a Board of Directors. The Board meets roughly one a month a
 - The Board will execute a Memorandum of Understanding with the TIDES Manager that outlines the roles, responsibilities, and limitations of the management role.
 - The Board may change the management of TIDES at any time for any reason.
 - When there is no TIDES Manager assigned, the Board will take over management in the interim.
+- The TIDES Manager conducts its activities in coordination and collaboration with Working Groups and other entities chartered by the Board, and makes reasonable accommodations within its existing responsibilities (for example, GitHub access for Working Group chairs). The Manager is not responsible for staffing or facilitating Working Groups.
 
 ### TIDES Program Manager
 
@@ -90,10 +94,25 @@ TIDES is governed by a Board of Directors. The Board meets roughly one a month a
 
 ### Management Implementation and Principles
 
-- The TIDES Program Manager will be assigned as an Owner of the GitHub Organization for TIDES (along with each member of the Board).
+- The TIDES Board Coordinator will provide the TIDES Program Manager and other staff with the necessary access, authority, and resources to perform their obligations effectively. Working Group chair access is defined by each chair agreement (see [Working Groups](#working-groups)).
 - The TIDES Manager will solicit, review, approve, and manage requests by individuals to be assigned as a TIDES Contributor.
 - The TIDES Manager will remove Contributors at their discretion, including situations when the Contributor violates the Contributor agreement.
 - The TIDES Manager will, with the input and concurrence of the Board of Directors, establish and manage the process for modifying the TIDES spec over time.
+
+### Working Groups
+
+The TIDES Board may charter **Working Groups** to carry ongoing or time-boxed work on the specification, tooling, documentation, and community engagement. Current groups, their charters, chairs, and how to join are listed in the [TIDES Working Groups registry](governance/working-groups.md).
+
+- Working Groups are distinct from the Issue Resolution Groups defined in the [Change Management Policy](governance/policies/change-management.md).
+- Each Working Group operates under a written, Board-approved charter (purpose, scope, chair(s), rights, timeline, review cadence).
+- Each Working Group has one or more Board-appointed chairs (for example a Chair and Deputy Chair) who sign a written agreement defining their rights and responsibilities and are removable by the Board at any time.
+- Chairs may be granted defined GitHub rights (repository Write via a Board-administered team) as Board-designees, scoped to their charter, not organization ownership.
+- Members and chairs of Working Groups are volunteers; their time may be sponsored by their employers; they are not staff of the TIDES Board or the TIDES Manager.
+- Working Groups are open to anyone. Each charter states how to join (a published sign-up or contact path), the group’s meeting cadence, and any limits on participation. If a group limits membership, the charter says so and gives the criteria and how to request to join.
+- Joining a Working Group includes registering as a TIDES Contributor, which carries agreement to the TIDES Code of Conduct; anyone may observe public working sessions without registering.
+- Chairs maintain the membership list and share it with the Board and the TIDES Manager.
+- Working Groups work in the open, recording agendas, decisions, and outcomes through lightweight public channels (e.g., GitHub Issues and Discussions), without formal minute-taking requirements. A group may use a non-public working space to mature draft material, provided the charter discloses it and the way to opt in.
+- Members may be removed only through the TIDES Code of Conduct process (unlike chairs, who serve at the Board’s pleasure).
 
 ### TIDES Contributor
 
@@ -106,6 +125,11 @@ TIDES is governed by a Board of Directors. The Board meets roughly one a month a
 - Anyone who has an interest in or could be directly affected by the TIDES specification and tools.
 
 ## Document History
+
+### 2026-09
+
+- Updated per the [2026-08-27 Board approval](https://docs.google.com/document/d/1C-qynGan-jh4z1bJH_Qv3mJX0lXCHHKkzdrEgJzl3QY/edit?usp=sharing): added the Working Groups section and registry, updated Board meeting cadence, GitHub organization asset language, TIDES Manager coordination with Working Groups, Board decisions list, and management implementation language.
+- Updated the TIDES Program Manager assignment to Carl Fredlund, MobilityData, and Board member affiliations.
 
 ### 2023-12-04
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -101,7 +101,7 @@ TIDES is governed by a Board of Directors. The Board holds quarterly strategic m
 
 ### Working Groups
 
-The TIDES Board may charter **Working Groups** to carry ongoing or time-boxed work on the specification, tooling, documentation, and community engagement. Current groups, their charters, chairs, and how to join are listed in the [TIDES Working Groups registry](governance/working-groups.md).
+The TIDES Board may charter **Working Groups**, standing or formed for a limited time, to carry work on the specification, tooling, documentation, and community engagement. Current groups, their charters, chairs, and how to join are listed in the [TIDES Working Groups registry](governance/working-groups.md).
 
 - Working Groups are distinct from the Issue Resolution Groups defined in the [Change Management Policy](governance/policies/change-management.md).
 - Each Working Group operates under a written, Board-approved charter (purpose, scope, chair(s), rights, timeline, review cadence).

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -35,7 +35,7 @@ TIDES is collectively owned and governed by a Board of Directors.
 
 ### TIDES Board of Directors
 
-TIDES is governed by a Board of Directors. The Board holds quarterly strategic meetings with the TIDES Manager; the Board Coordinator may convene additional Board meetings as needed. The Board has a [public agenda and minutes](https://docs.google.com/document/d/1C-qynGan-jh4z1bJH_Qv3mJX0lXCHHKkzdrEgJzl3QY/edit?usp=sharing).
+TIDES is governed by a Board of Directors. The Board holds quarterly strategic meetings with the TIDES Manager. The Board Coordinator may convene additional Board meetings as needed. The Board has a [public agenda and minutes](https://docs.google.com/document/d/1C-qynGan-jh4z1bJH_Qv3mJX0lXCHHKkzdrEgJzl3QY/edit?usp=sharing).
 
 #### Board Membership
 
@@ -64,8 +64,8 @@ TIDES is governed by a Board of Directors. The Board holds quarterly strategic m
     - Review and approve each new release of TIDES.
     - Manage Urgent Changes to the standard in collaboration with the TIDES Manager.
     - Resolve issues that arise during the Change Management process that cannot be addressed by the TIDES Manager.
-    - Charter Working Groups and approve their written charters.
-    - Appoint Working Group chairs and approve each chair’s written agreement.
+    - Establish Working Groups and approve their written charters.
+    - Appoint Working Group chairs.
 
 #### Board Member Role and Term
 
@@ -84,7 +84,7 @@ TIDES is governed by a Board of Directors. The Board holds quarterly strategic m
 - The Board will execute a Memorandum of Understanding with the TIDES Manager that outlines the roles, responsibilities, and limitations of the management role.
 - The Board may change the management of TIDES at any time for any reason.
 - When there is no TIDES Manager assigned, the Board will take over management in the interim.
-- The TIDES Manager conducts its activities in coordination and collaboration with Working Groups and other entities chartered by the Board, and makes reasonable accommodations within its existing responsibilities (for example, GitHub access for Working Group chairs). The Manager is not responsible for staffing or facilitating Working Groups.
+- The TIDES Manager conducts its activities in coordination and collaboration with Working Groups and other entities established by the Board, and facilitates the work of those groups. The TIDES Manager is not responsible for staffing or managing Working Groups.
 
 ### TIDES Program Manager
 
@@ -126,7 +126,7 @@ The TIDES Board may charter **Working Groups** to carry ongoing or time-boxed wo
 
 ## Document History
 
-### 2026-09
+### 2026-09-08
 
 - Updated per the [2026-08-27 Board approval](https://docs.google.com/document/d/1C-qynGan-jh4z1bJH_Qv3mJX0lXCHHKkzdrEgJzl3QY/edit?usp=sharing): added the Working Groups section and registry, updated Board meeting cadence, GitHub organization asset language, TIDES Manager coordination with Working Groups, Board decisions list, and management implementation language.
 - Updated the TIDES Program Manager assignment to Carl Fredlund, MobilityData, and Board member affiliations.

--- a/docs/governance/policies/change-management.md
+++ b/docs/governance/policies/change-management.md
@@ -79,6 +79,13 @@ This change-making process covers all [normative content](#normative-content) ch
     * `examples`
     * `context`
 
+### Working Groups and Issue Resolution Groups
+
+Two kinds of groups take part in the change-making process:
+
+* **Working Groups** are standing or time-boxed groups chartered by the TIDES Board, as defined in the [TIDES Governance document][TIDES-governance]. These include the standing Standards Development Working Group (SDWG) and topic-focused groups (for example, around National Transit Database reporting or on-time performance). Working Groups follow this policy for any normative change.
+* **Issue Resolution Groups** are convened to develop a resolution to a prioritized issue or set of interrelated issues, drawing members from interested Contributors. They were previously called “Issue Working Groups” in this policy; the name is changed to avoid confusion with Board-chartered Working Groups.
+
 ### Change-making Stages
 
 The process by which normative changes are made to the TIDES data specification occurs in the following stages:
@@ -86,11 +93,13 @@ The process by which normative changes are made to the TIDES data specification 
 | Stage | When | Who (led by) |
 |-----|-----|-----|
 | Need Identification | Anytime | Anyone |
-| Prioritization | Quarterly (or as determined by TIDES Board or TIDES Manager) | Contributors (Manager) |
-| Proposal Development  | Prioritized quarter | Working Group (Manager) |
-| Review + Adoption | Pull request for proposed change submitted after consensus in the Working Group | Working Group (Manager) |
-| Implementation | When decision made to consensus achieved on proposal | Working Group (Manager) |
+| Prioritization | Quarterly (or as determined by TIDES Board or TIDES Manager) | Contributors (Manager or Working Group Chair) |
+| Proposal Development  | Prioritized quarter | Issue Resolution Group (Manager or Working Group Chair) |
+| Review + Adoption | Pull request for proposed change submitted after consensus in the Issue Resolution Group | Issue Resolution Group (Manager or Working Group Chair) |
+| Implementation | When decision made to consensus achieved on proposal | Issue Resolution Group (Manager or Working Group Chair) |
 | Released | Next quarterly release | Manager |
+
+By default, a Working Group Chair leads the Proposal Development, Review + Adoption, and Implementation stages for work within their charter’s scope. The TIDES Manager retains the governance-compliance review at the version-release gate and acts as backstop where Manager authority is specifically required or no chair is seated. The Board continues to approve the prioritized change list and each release.
 
 Each of these stages is discussed in more detail below.
 
@@ -120,37 +129,37 @@ Each of these stages is discussed in more detail below.
 
 === ":material-pencil: Proposal Development"
 
-    :material-calendar-start: TIDES Manager, in consultation with the TIDES Board and TIDES Contributors, convenes an Issue Working Group to address a prioritized issue or set of interrelated issues.
+    :material-calendar-start: A Working Group or the TIDES Manager convenes an Issue Resolution Group to address a prioritized issue or set of interrelated issues, drawing members from interested Contributors.
 
     :material-checkbox-multiple-marked-circle-outline: **Actions**:
 
-    - [ ] TIDES Manager convenes an Issue Working Group to develop a resolution to the issue.
-    - [ ] The TIDES Manager will invite those who have expressed interest in the issue (including the issue creator and commenters) and who they believe will have an interest in the topic to take part on the Issue Working Group. They will also solicit participation from all TIDES Contributors.
-    - [ ] Working Group members document discussion points about approach in the relevant github issue.
-    - [ ] While consensus will be sought, if the Working Group members cannot come to a unanimous agreement about the solution, the TIDES Manager may ask the TIDES Board to make a decision after hearing feedback from various perspectives.
-    - [ ] Working Group members update the schema and documentation according to the proposal on a feature branch.
+    - [ ] A Working Group or the TIDES Manager convenes an Issue Resolution Group to develop a resolution to the issue.
+    - [ ] The convener will invite those who have expressed interest in the issue (including the issue creator and commenters) and who they believe will have an interest in the topic to take part on the Issue Resolution Group. They will also solicit participation from all TIDES Contributors.
+    - [ ] Issue Resolution Group members document discussion points about approach in the relevant github issue.
+    - [ ] While consensus will be sought, if the Issue Resolution Group members cannot come to a unanimous agreement about the solution, the TIDES Manager may ask the TIDES Board to make a decision after hearing feedback from various perspectives.
+    - [ ] Issue Resolution Group members update the schema and documentation according to the proposal on a feature branch.
 
-    :material-check-underline: **Resolution**: Working Group submits a pull request to the `develop` branch.
+    :material-check-underline: **Resolution**: Issue Resolution Group submits a pull request to the `develop` branch.
 
 === ":octicons-comment-discussion-24: Review + :material-vote: Adoption"
 
-    :material-calendar-start: TIDES Manager invites people outside of the Working Group to review and comment on the proposal
+    :material-calendar-start: TIDES Manager invites people outside of the Issue Resolution Group to review and comment on the proposal
 
     :material-checkbox-multiple-marked-circle-outline: **Actions**:
 
-    - [ ] The TIDES Manager MUST invite people outside of the Working Group to review and comment on the Pull Request for the proposal for a minimum of two weeks, making sure TIDES Contributors with different roles and backgrounds have had a chance to consider it.
+    - [ ] The TIDES Manager MUST invite people outside of the Issue Resolution Group to review and comment on the Pull Request for the proposal for a minimum of two weeks, making sure TIDES Contributors with different roles and backgrounds have had a chance to consider it.
     - [ ] The TIDES Manager MUST review the proposal for consistency with the Open Standards Definition maintained by the [Mobility Data Interoperability Principles](http://interoperablemobility.org).
     - [ ] The TIDES Manager MUST offer tools, services and  assistance to any TIDES Contributor who is unable to fluidly interact with the tooling used in the review process.
-    - [ ] A minimum of three TIDES Contributors outside the Working Group MUST publicly comment on each proposal for it to move forward  and indicate a score of:
+    - [ ] A minimum of three TIDES Contributors outside the Issue Resolution Group MUST publicly comment on each proposal for it to move forward  and indicate a score of:
         * Accepted;
         * Accepted with minor changes; or
         * Substantially revised.
     - [ ] If 100% of reviewers accept, the proposal is adopted without need for further discussion.
-    - [ ] If any reviewer accepts with minor changes, the suggested change must be considered by the Working Group.
-        * If the Working Group decides to incorporate the edited proposal will be re-circulated for some period time greater than 72 hours and previous reviewers notified.  If nobody objects to the change in that time, it is adopted.
-        * If the Working Group does not agree with the suggested change, they may appeal to the TIDES Board to make a final decision about its necessity.
-    - [ ] If any reviewer requests substantial changes, they must also agree to work with the working group on developing an alternative solution to the need.
-        * If the working group believes the substantial change request is invalid or without merit, they may appeal to the TIDES Board to make a final decision about if revisions are necessary.
+    - [ ] If any reviewer accepts with minor changes, the suggested change must be considered by the Issue Resolution Group.
+        * If the Issue Resolution Group decides to incorporate the edited proposal will be re-circulated for some period time greater than 72 hours and previous reviewers notified.  If nobody objects to the change in that time, it is adopted.
+        * If the Issue Resolution Group does not agree with the suggested change, they may appeal to the TIDES Board to make a final decision about its necessity.
+    - [ ] If any reviewer requests substantial changes, they must also agree to work with the Issue Resolution Group on developing an alternative solution to the need.
+        * If the Issue Resolution Group believes the substantial change request is invalid or without merit, they may appeal to the TIDES Board to make a final decision about if revisions are necessary.
 
     :material-check-underline: **Resolution:** Change as represented in the pull request from the feature branch is approved and merged into the `develop` branch.
 
@@ -306,7 +315,7 @@ The following branches SHOULD always be maintained:
     - [ ] TIDES Manager MAY release commits periodically as a [pre-release](#pre-releases)(s).
     - [ ] SHOULD only be updated from `main` branch or PRs whereby:
         * TIDES Manager SHOULD periodically update this branch with any non-normative changes accepted into `main`.
-        * PRs MUST be approved by TIDES Manager or their designee  and their approval MUST represent that:
+        * PRs MUST be approved by the TIDES Manager or an authorized Working Group Chair  and their approval MUST represent that:
             * the [governance process](#contributor-review-adoption) for approving a normative change to the standard has been met; and
             * that the change meets all the requirements outlined in the [pre-release requirements](#pre-releases).
 
@@ -324,6 +333,10 @@ The following branches SHOULD always be maintained:
 * [Open Contracting Data Standard](https://standard.open-contracting.org/latest/en/governance/)
 
 ## Revision History
+
+### v1.1 2026-09
+
+* Updated per the [2026-08-27 TIDES Board approval](https://docs.google.com/document/d/1C-qynGan-jh4z1bJH_Qv3mJX0lXCHHKkzdrEgJzl3QY/edit?usp=sharing): renamed “Issue Working Group” to “Issue Resolution Group,” recognized Board-chartered Working Groups, allowed Working Group Chairs to lead change-making stages within their charter’s scope, and authorized Working Group Chairs to approve pull requests to the `develop` branch.
 
 ### v1.0 2023-11-29 Initial Version
 

--- a/docs/governance/policies/change-management.md
+++ b/docs/governance/policies/change-management.md
@@ -83,7 +83,7 @@ This change-making process covers all [normative content](#normative-content) ch
 
 Two kinds of groups take part in the change-making process:
 
-* **Working Groups** are standing or time-boxed groups chartered by the TIDES Board, as defined in the [TIDES Governance document][TIDES-governance]. These include the standing Standards Development Working Group (SDWG) and topic-focused groups (for example, around National Transit Database reporting or on-time performance). Working Groups follow this policy for any normative change.
+* **Working Groups** are groups chartered by the TIDES Board, standing or formed for a limited time, as defined in the [TIDES Governance document][TIDES-governance]. These include the standing Standards Development Working Group (SDWG) and topic-focused groups chartered as champions emerge. Working Groups follow this policy for any normative change.
 * **Issue Resolution Groups** are convened to develop a resolution to a prioritized issue or set of interrelated issues, drawing members from interested Contributors. They were previously called “Issue Working Groups” in this policy; the name is changed to avoid confusion with Board-chartered Working Groups.
 
 ### Change-making Stages

--- a/docs/governance/policies/change-management.md
+++ b/docs/governance/policies/change-management.md
@@ -83,7 +83,7 @@ This change-making process covers all [normative content](#normative-content) ch
 
 Two kinds of groups take part in the change-making process:
 
-* **Working Groups** are groups chartered by the TIDES Board, standing or formed for a limited time, as defined in the [TIDES Governance document][TIDES-governance]. These include the standing Standards Development Working Group (SDWG) and topic-focused groups chartered as champions emerge. Working Groups follow this policy for any normative change.
+* **Working Groups** are chartered by the TIDES Board, as defined in the [TIDES Governance document][TIDES-governance]. These include the standing Standards Development Working Group (SDWG) and topic-focused groups. Working Groups follow this policy for any normative change.
 * **Issue Resolution Groups** are convened to develop a resolution to a prioritized issue or set of interrelated issues, drawing members from interested Contributors. They were previously called “Issue Working Groups” in this policy; the name is changed to avoid confusion with Board-chartered Working Groups.
 
 ### Change-making Stages

--- a/docs/governance/working-groups.md
+++ b/docs/governance/working-groups.md
@@ -1,0 +1,26 @@
+# TIDES Working Groups
+
+The TIDES Board of Directors charters Working Groups to carry ongoing or time-boxed work on the TIDES specification, tooling, documentation, and community engagement. Each Working Group operates under a written, Board-approved charter, has one or more Board-appointed chairs (for example a Chair and Deputy Chair), and follows the [TIDES Change Management Policy](policies/change-management.md) for any changes to the specification. See the [TIDES Governance document](../governance.md#working-groups) for how Working Groups are chartered and governed.
+
+Working Groups are open to anyone. Each group's charter states how to join, the group's meeting cadence, and any limits on participation. Joining a Working Group includes registering as a TIDES Contributor, which carries agreement to the TIDES Code of Conduct; anyone may observe public working sessions without registering.
+
+## Active Working Groups
+
+### Standards Development Working Group (SDWG)
+
+| | |
+| --- | --- |
+| **Status** | Active. Chartered by the TIDES Board on August 27, 2026 |
+| **Charter** | [SDWG Charter](working-groups/sdwg-charter.md) |
+| **Chair** | *To be announced* |
+| **Deputy Chair** | *To be announced* |
+| **Meets** | Monthly by video call; schedule and connection details announced through TIDES community channels |
+| **How to join** | Register as a TIDES Contributor via the [registration form][contributor-registration], then contact the chairs |
+
+The SDWG is the standing Working Group responsible for the ongoing technical development of the TIDES specification and its documentation: advancing proposed changes through the change management process, maintaining the specification's quality and consistency, and coordinating TIDES with related open standards. It carries forward the work of the TIDES Contributors Group.
+
+## Proposing a new Working Group
+
+Topic-focused Working Groups (for example, around specific use cases such as National Transit Database reporting or on-time performance) are chartered by the Board as champions and participation emerge. To propose a Working Group, contact the TIDES Board or open a [Discussion on GitHub](https://github.com/TIDES-transit/TIDES/discussions).
+
+[contributor-registration]: https://docs.google.com/forms/d/e/1FAIpQLSfQUjKHfV64uDBAYAt0OSPgYCe_BGgcAPWXi-m0PSlX6edCIQ/viewform?usp=header

--- a/docs/governance/working-groups.md
+++ b/docs/governance/working-groups.md
@@ -21,6 +21,6 @@ The SDWG is the standing Working Group responsible for the ongoing technical dev
 
 ## Proposing a new Working Group
 
-Topic-focused Working Groups are chartered by the Board as champions and participation emerge. To propose a Working Group, contact the TIDES Board or open a [Discussion on GitHub](https://github.com/TIDES-transit/TIDES/discussions).
+To propose a Working Group, contact the TIDES Board or open a [Discussion on GitHub](https://github.com/TIDES-transit/TIDES/discussions).
 
 [contributor-registration]: https://docs.google.com/forms/d/e/1FAIpQLSfQUjKHfV64uDBAYAt0OSPgYCe_BGgcAPWXi-m0PSlX6edCIQ/viewform?usp=header

--- a/docs/governance/working-groups.md
+++ b/docs/governance/working-groups.md
@@ -1,6 +1,6 @@
 # TIDES Working Groups
 
-The TIDES Board of Directors charters Working Groups to carry ongoing or time-boxed work on the TIDES specification, tooling, documentation, and community engagement. Each Working Group operates under a written, Board-approved charter, has one or more Board-appointed chairs (for example a Chair and Deputy Chair), and follows the [TIDES Change Management Policy](policies/change-management.md) for any changes to the specification. See the [TIDES Governance document](../governance.md#working-groups) for how Working Groups are chartered and governed.
+The TIDES Board of Directors charters Working Groups, standing or formed for a limited time, to carry work on the TIDES specification, tooling, documentation, and community engagement. Each Working Group operates under a written, Board-approved charter, has one or more Board-appointed chairs (for example a Chair and Deputy Chair), and follows the [TIDES Change Management Policy](policies/change-management.md) for any changes to the specification. See the [TIDES Governance document](../governance.md#working-groups) for how Working Groups are chartered and governed.
 
 Working Groups are open to anyone. Each group's charter states how to join, the group's meeting cadence, and any limits on participation. Joining a Working Group includes registering as a TIDES Contributor, which carries agreement to the TIDES Code of Conduct; anyone may observe public working sessions without registering.
 
@@ -21,6 +21,6 @@ The SDWG is the standing Working Group responsible for the ongoing technical dev
 
 ## Proposing a new Working Group
 
-Topic-focused Working Groups (for example, around specific use cases such as National Transit Database reporting or on-time performance) are chartered by the Board as champions and participation emerge. To propose a Working Group, contact the TIDES Board or open a [Discussion on GitHub](https://github.com/TIDES-transit/TIDES/discussions).
+Topic-focused Working Groups are chartered by the Board as champions and participation emerge. To propose a Working Group, contact the TIDES Board or open a [Discussion on GitHub](https://github.com/TIDES-transit/TIDES/discussions).
 
 [contributor-registration]: https://docs.google.com/forms/d/e/1FAIpQLSfQUjKHfV64uDBAYAt0OSPgYCe_BGgcAPWXi-m0PSlX6edCIQ/viewform?usp=header

--- a/docs/governance/working-groups/sdwg-charter.md
+++ b/docs/governance/working-groups/sdwg-charter.md
@@ -1,0 +1,67 @@
+# TIDES Standards Development Working Group Charter
+
+Charter for the Transit Integrated Data Exchange Specification (TIDES) Standards Development Working Group (SDWG)
+
+## 1. Purpose
+
+The Standards Development Working Group (SDWG) is a standing Working Group chartered by the TIDES Board of Directors. It is responsible for the ongoing technical development of the TIDES specification and its documentation: advancing proposed changes through the change management process, maintaining the quality and consistency of the specification, and coordinating TIDES with related open standards.
+
+## 2. Scope of work
+
+* Triage, review, and merge proposed changes to the specification per the TIDES Change Management Policy, including merges into the `develop` branch.
+* Maintain and improve the specification's documentation.
+* Maintain terminology consistency across the specification.
+* Coordinate alignment between TIDES and related specifications, including GTFS and TODS.
+* Surface prioritized issues and, where warranted, convene Issue Resolution Groups as defined in the Change Management Policy.
+* Prepare releases of the specification for Board review and approval.
+
+**Out of scope:** final release approval (retained by the TIDES Board); the governance-compliance review at the version-release gate (retained by the TIDES Manager); hosting and administration of the TIDES platforms and repositories (performed by the TIDES Manager).
+
+## 3. Relationship to TIDES governance
+
+The SDWG operates under the structures and processes defined in the [TIDES Governance document](../../governance.md) and the [TIDES Change Management Policy](../policies/change-management.md). Normative changes to the specification and its version-controlled documentation are coordinated with the TIDES Manager and approved by the TIDES Board as those documents require. Within its scope, the SDWG may manage Issues, Pull Requests, and Discussions independently. The SDWG's chairs act as authorized Working Group Chairs under the Change Management Policy for merges into the `develop` branch.
+
+## 4. Chairs
+
+The SDWG's Chair and Deputy Chair are appointed by the TIDES Board, sign written chair agreements with the Board defining their rights and responsibilities, and may be removed or replaced by the Board at any time, as provided for all Working Group chairs in the TIDES Governance document. The Chair is the group's primary lead and point of contact, responsible for reporting to the Board and the TIDES Manager. The Deputy Chair supports the Chair across all of the group's duties and acts fully for the Chair when the Chair is unavailable.
+
+Current chair appointments are listed in the [TIDES Working Groups registry](../working-groups.md).
+
+### Responsibilities of the chairs
+
+* Call and run the group's regular meetings, set agendas, and publish notes of decisions and outcomes.
+* Maintain the group's membership list and share it with the Board and the TIDES Manager.
+* Report on the group's work at the quarterly meetings of the TIDES Board and TIDES Manager.
+* Coordinate the group's work with the TIDES Manager and the TIDES Board.
+
+### Rights of the chairs
+
+SDWG Chairs receive Repository Write access on the TIDES specification repository, including authorization to merge approved changes into the `develop` branch under the Change Management Policy. Chair rights are defined in the chair agreement approved by the Board. Chair rights do not include organization ownership or repository administration, which remain with the TIDES Board and TIDES Manager as defined by the TIDES Governance document.
+
+## 5. Membership and participation
+
+The SDWG carries forward the work of the TIDES Contributors Group: its recurring meeting continues as the SDWG's regular meeting, and existing Contributors Group participants become members of the SDWG at chartering unless they opt out.
+
+Membership in the SDWG is open to anyone. Members must register as TIDES Contributors, which carries agreement to the TIDES Code of Conduct. Information on becoming a TIDES Contributor and a member of a working group is included in the [Contributing to TIDES documentation](../../development.md).
+
+Anyone may observe the group's public working sessions and review the group's notes without registering as a Contributor or joining the SDWG.
+
+Members and chairs of the SDWG are volunteers. They are not staff of the TIDES Board or the TIDES Manager. Members and chairs may have their time sponsored by their employers. Members may only be removed due to a violation of the [TIDES Code of Conduct](../policies/code-of-conduct.md); violations will be addressed through the process defined in that document.
+
+## 6. Ways of working
+
+* The SDWG shall generally meet **monthly** by video call, with schedule and connection details announced through TIDES community channels. The Chair may adjust meeting timing and cadence as needed.
+* The group works in the open: agendas, decisions, and outcomes are recorded through public channels such as GitHub Issues and Discussions. Formal meeting minutes are not required.
+* The group maintains no non-public working spaces. If that changes, this charter will be amended to disclose the space and how to opt in.
+
+## 7. Decision-making
+
+The SDWG works by consensus. In order to reach consensus, there must be no members “blocking” the decision. Where consensus on a normative change cannot be reached, the matter is escalated per the Change Management Policy. Nothing in this charter overrides the TIDES Board's approval authority over prioritized changes and releases.
+
+## 8. Term and review
+
+The SDWG is a standing Working Group. This charter is reviewed annually by the TIDES Board, which may amend or revoke it, or change the group's chairs, at any time.
+
+*Adopted by the TIDES Board of Directors on August 27, 2026.*
+
+Charter version 1.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,8 +91,11 @@ nav:
   - Contributing:
       - Development: development.md
       - Documentation: documentation.md
-  - Governance: 
+  - Governance:
       - Governance Structure: governance.md
+      - Working Groups:
+          - Working Groups Registry: governance/working-groups.md
+          - SDWG Charter: governance/working-groups/sdwg-charter.md
       - Change Management: governance/policies/change-management.md
       - Other Policies: 
           - Code of conduct: governance/policies/code-of-conduct.md


### PR DESCRIPTION
This PR implements the document changes the TIDES Board approved at its August 27, 2026 meeting. Minutes are in the [TIDES Board Rolling Agenda & Minutes](https://docs.google.com/document/d/1C-qynGan-jh4z1bJH_Qv3mJX0lXCHHKkzdrEgJzl3QY/edit?usp=sharing). The Board approved the [description of planned changes to the Governance and Change Management Policy documents](https://docs.google.com/document/d/1OcwaeugxsOHBRNpCGENJfnSoIR6ci95slTqT0BScmHE/edit?tab=t.0) and the [Standards Development Working Group charter](https://docs.google.com/document/d/1OcwaeugxsOHBRNpCGENJfnSoIR6ci95slTqT0BScmHE/edit?tab=t.7pji89aateo1), each 4 in favor, 0 against.

**Governance document (`docs/governance.md`)**

- Adds a Working Groups section: Board-chartered groups with written charters, Board-appointed chairs under signed agreements, open membership, and work in the open.
- Adds Working Groups to the roles table, pointing to a new registry page.
- Updates the Board meeting cadence to quarterly strategic meetings with the TIDES Manager, with additional Board meetings convened as needed.
- Replaces the per-member GitHub Owner assignment with the Board Coordinator's responsibility for maintaining control of core TIDES assets. Specific owner sets, permission levels, and settings live in the asset management agreement between the Board Coordinator and the Manager.
- Adds Working Group chartering and chair appointments to the Board decisions list, adds a Manager coordination bullet, and updates the management implementation language to match.
- Updates the Program Manager assignment to Carl Fredlund, MobilityData, and updates Board member affiliations.

**Change Management Policy (`docs/governance/policies/change-management.md`)**

- Renames "Issue Working Group" to "Issue Resolution Group" throughout the change-making stages, removing the name collision with Board-chartered Working Groups.
- Recognizes Working Groups in the policy. By default, a Working Group Chair leads the Proposal Development, Review + Adoption, and Implementation stages for work within their charter's scope; the Manager retains the governance-compliance review at the version-release gate.
- Authorizes Working Group Chairs, alongside the TIDES Manager, to approve pull requests into `develop`.

**New pages**

- `docs/governance/working-groups.md`: the TIDES Working Groups registry, with the SDWG as its first entry.
- `docs/governance/working-groups/sdwg-charter.md`: the Board-approved SDWG charter, adopted August 27, 2026. Per the Board's direction, chair appointments are not named in the charter itself; they will be recorded in the registry once the chair agreements are executed.

Not included here, by design: the updated MOU (executed separately by the Board and MobilityData), the GitHub settings changes that implement this structure (handled by the Board Coordinator with the Manager's IT administration per the approved plan), and a follow-on wording pass on the Expedited Change Management section.

Opening as a draft while the chair appointments are finalized for the registry. Board review is welcome in the meantime; this PR touches code-owned governance paths, so it needs Board code-owner review to merge.
